### PR TITLE
Fix project template imports with Node 12

### DIFF
--- a/packages/uikit/templates/project/src/server/dev.mjs
+++ b/packages/uikit/templates/project/src/server/dev.mjs
@@ -3,7 +3,7 @@ import hotMiddleware from 'webpack-hot-middleware';
 import webpack from 'webpack';
 
 import app from './index.mjs';
-import webpackConfig from '../../config/development.webpack.config';
+import webpackConfig from '../../config/development.webpack.config.js';
 
 const port = process.env.PORT || 3000;
 const compiler = webpack(webpackConfig);

--- a/packages/uikit/templates/project/src/server/prod.mjs
+++ b/packages/uikit/templates/project/src/server/prod.mjs
@@ -1,7 +1,7 @@
 import express from 'express';
 
 import app from './index.mjs';
-import paths from '../../config/paths';
+import paths from '../../config/paths.js';
 
 const port = process.env.PORT || 3000;
 


### PR DESCRIPTION
@genebean ran into problems with the uikit project generator using Node 12, though it works on Node 10 LTS (which we worked through in [#aff-react](https://puppet.slack.com/messages/CF7H2EPLG)). There must be a difference in imports with the latest module system. Adding the file extension for local paths fixes the issue on Node 12 without breaking it in Node 10.