### PR TITLE
Truncate Sidebar Footer Details

### DIFF
--- a/packages/react-components/source/scss/library/components/_sidebar.scss
+++ b/packages/react-components/source/scss/library/components/_sidebar.scss
@@ -53,6 +53,7 @@ $puppet-sidebar-item-accordion-padding: 0 0 0 8px !default;
 
 $puppet-sidebar-footer-height: 72px !default;
 $puppet-sidebar-footer-bg: $puppet-black !default;
+$puppet-sidebar-footer-meta-icon: 32px;
 
 // Generic sidebar
 
@@ -247,6 +248,14 @@ $puppet-sidebar-footer-bg: $puppet-black !default;
   padding: $puppet-sidebar-padding;
   text-align: left;
   text-decoration: none !important;
+
+  .rc-sidebar-footer-meta-username,
+  .rc-sidebar-footer-meta-version {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: $puppet-sidebar-width - $puppet-sidebar-padding * 3 - $puppet-sidebar-footer-meta-icon;
+  }
 }
 
 .rc-sidebar-footer:hover,
@@ -281,9 +290,9 @@ $puppet-sidebar-footer-bg: $puppet-black !default;
   background: $puppet-n500;
   border-radius: 100px;
   display: flex;
-  height: 32px;
+  height: $puppet-sidebar-footer-meta-icon;
   justify-content: center;
-  width: 32px;
+  width: $puppet-sidebar-footer-meta-icon;
 
   .rc-icon {
     fill: $puppet-sidebar-footer-bg;


### PR DESCRIPTION
This truncates footer details with ellipses.

<img width="239" alt="Screen Shot 2019-07-16 at 2 46 15 PM" src="https://user-images.githubusercontent.com/11082532/61332192-7dfcba00-a7d8-11e9-9a4b-8d6c265b7598.png">
