### PR TITLE
Add corejs as dependency in react-components and react-layouts

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -39,7 +39,6 @@
     "chai": "^4.2.0",
     "chai-enzyme": "^1.0.0-beta.1",
     "cheerio": "^1.0.0-rc.2",
-    "core-js": "^3.1.4",
     "css-loader": "^3.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
@@ -80,6 +79,7 @@
   "dependencies": {
     "@puppet/sass-variables": "^1.0.1",
     "classnames": "^2.2.6",
+    "core-js": "^3.1.4",
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/packages/react-layouts/package.json
+++ b/packages/react-layouts/package.json
@@ -24,6 +24,7 @@
     "@puppet/react-components": "^5.2.1",
     "@puppet/sass-variables": "^1.0.1",
     "classnames": "^2.2.6",
+    "core-js": "^3.1.4",
     "prop-types": "^15.7.2",
     "react": "^16.8.6"
   },
@@ -45,7 +46,6 @@
     "clean-webpack-plugin": "^3.0.0",
     "connect-history-api-fallback": "^1.6.0",
     "copy-webpack-plugin": "^5.0.3",
-    "core-js": "^3.1.4",
     "css-loader": "^3.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",


### PR DESCRIPTION
* require statements importing core-js are automatically added by babel polyfill on library builds