### PR TITLE
Export array of icons as Icon.icons

### DIFF
--- a/packages/react-components/source/react/library/icon/index.js
+++ b/packages/react-components/source/react/library/icon/index.js
@@ -1,3 +1,7 @@
 import Icon from './Icon';
+import icons from './icons';
+
+// This gives consumers access to the list of icons, e.g. for use in other styleguides
+Icon.icons = icons;
 
 export default Icon;


### PR DESCRIPTION
This exposes the list of icons as `Icon.icons` for use by consumers. This was requested in https://github.com/puppetlabs/kusama/pull/69 for the marketing Styleguidist.