### PR TITLE
Replace deprecated use of componentWillReceiveProps with componentDidUpdate

### DIFF
--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
@@ -92,9 +92,9 @@ class OptionMenuList extends Component {
     this.onActionBlur = this.onActionBlur.bind(this);
   }
 
-  componentWillReceiveProps(props) {
-    const { options, focusedIndex } = props;
-    const { focusedIndex: oldFocusedIndex } = this.state;
+  componentDidUpdate(prevProps, prevState) {
+    const { options, focusedIndex } = this.props;
+    const { focusedIndex: oldFocusedIndex } = prevState;
 
     if (options.length && focusedIndex !== oldFocusedIndex) {
       this.focusItem(focusedIndex);


### PR DESCRIPTION
Use of this deprecated prop was producing the following warning in nebula-ui:

```
    console.warn node_modules/react-dom/cjs/react-dom.development.js:12386
      Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

      * Move data fetching code or side effects to componentDidUpdate.
      * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
      * Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

      Please update the following components: OptionMenuList
```