### PR TITLE
Fix keyboard navigation bug in ButtonSelect

### DIFF
--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
@@ -92,11 +92,15 @@ class OptionMenuList extends Component {
     this.onActionBlur = this.onActionBlur.bind(this);
   }
 
+  // Update focused item for autocomplete
   componentDidUpdate(prevProps, prevState) {
     const { options, focusedIndex } = this.props;
-    const { focusedIndex: oldFocusedIndex } = prevState;
 
-    if (options.length && focusedIndex !== oldFocusedIndex) {
+    if (
+      options.length &&
+      focusedIndex !== prevProps.focusedIndex &&
+      focusedIndex !== prevState.focusedIndex
+    ) {
       this.focusItem(focusedIndex);
     }
   }


### PR DESCRIPTION
Fix keyboard navigation bug in ButtonSelect that was introduced by #143 in @puppet/react-components 5.9.5. Triggering a setState in componentDidUpdate should only be done inside a conditional comparing old and new props.

Resolves [PDS-384](https://tickets.puppetlabs.com/browse/PDS-384)