### PR TITLE
Fix caret icon overlapping text select component

### DIFF
--- a/packages/react-components/source/scss/library/components/forms/_select.scss
+++ b/packages/react-components/source/scss/library/components/forms/_select.scss
@@ -1,4 +1,5 @@
 .rc-select {
+  min-width: 100px;
   position: relative;
 
   .rc-select-target {
@@ -8,6 +9,7 @@
 
   .rc-select-target .rc-input {
     cursor: pointer;
+    padding-right: 30px;
     text-align: left;
   }
 


### PR DESCRIPTION
- I've added a minimum width to the component - similar to what button select has in place.
- To fix the overlapping issue I've added padding right 