### PR TITLE
Add `innerFocus` button variant

### DIFF
--- a/packages/react-components/source/react/library/button/Button.js
+++ b/packages/react-components/source/react/library/button/Button.js
@@ -26,10 +26,12 @@ const propTypes = {
   children: PropTypes.node,
   /** Optional trailing icon rendered after button text. For icon-only buttons, please use the 'icon' prop instead */
   trailingIcon: PropTypes.oneOf(AVAILABLE_ICONS),
-  /** Is the button disabled?  */
+  /** Is the button disabled? */
   disabled: PropTypes.bool,
   /** If true, button will render with a loading spinner */
   loading: PropTypes.bool,
+  /** If true, a focused button will use an inner instead of outer outline */
+  innerFocus: PropTypes.bool,
   /** Optional html button type override */
   buttonType: PropTypes.oneOf(['button', 'submit', 'reset']),
   /** Optional additional className. Additionally, all other props are propagated directly to the inner element */
@@ -45,6 +47,7 @@ const defaultProps = {
   icon: null,
   trailingIcon: null,
   loading: false,
+  innerFocus: false,
   disabled: false,
   buttonType: undefined,
   className: '',
@@ -77,6 +80,7 @@ const Button = forwardRef(
       icon,
       trailingIcon,
       loading,
+      innerFocus,
       buttonType,
       className,
       children,
@@ -98,6 +102,7 @@ const Button = forwardRef(
           'rc-button-trailing-icon': trailingIcon,
           'rc-button-empty': !children,
           'rc-button-full': children,
+          'rc-button-inner-focus': innerFocus,
         },
         className,
       )}

--- a/packages/react-components/source/react/library/button/Button.md
+++ b/packages/react-components/source/react/library/button/Button.md
@@ -289,6 +289,14 @@ If the design specifies a call-to-action (CTA) button that actually performs nav
 <Button as="a" href="http://google.com">Go to Google</Button>
 ```
 
+### Inner focus outline
+
+Add the boolean prop `innerFocus` in cases where a button is inside a container (e.g. toolbar, card) and needs the focus style to use an inner instead of outer outline so it doesn't bleed outside the container.
+
+```jsx
+<Button innerFocus>Focus me</Button>
+```
+
 ## Related
 
 - [ButtonSelect](#/React%20Components/ButtonSelect)

--- a/packages/react-components/source/scss/library/components/_button.scss
+++ b/packages/react-components/source/scss/library/components/_button.scss
@@ -124,6 +124,9 @@ $puppet-button-text: (
   ),
 );
 
+$puppet-button-padding-horizontal: 15px;
+$puppet-button-padding-vertical: 5px;
+
 @function disable($basestate) {
   $disabled: (
     background: disable-color(map-get($basestate, background)),
@@ -165,7 +168,7 @@ $puppet-button-text: (
   cursor: pointer;
   display: inline-block;
   outline: none;
-  padding: 5px 15px;
+  padding: $puppet-button-padding-vertical $puppet-button-padding-horizontal;
   position: relative;
   text-decoration: none;
   vertical-align: top;
@@ -185,12 +188,19 @@ $puppet-button-text: (
     top: 0;
   }
 
-  &:focus {
+  &:not(.rc-button-inner-focus):focus {
     box-shadow: $puppet-common-focus-outline;
   }
 
+  &.rc-button-inner-focus:focus {
+    border: 0;
+    box-shadow: $puppet-common-focus-outline-inset;
+    padding: ($puppet-button-padding-vertical + 1)
+      ($puppet-button-padding-horizontal + 1);
+  }
+
   &:disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     cursor: default;
     pointer-events: none;
   }


### PR DESCRIPTION
Resolves [PDS-373](https://tickets.puppetlabs.com/browse/PDS-373)

Adds `innerFocus` boolean prop to make focus style use an inner box-shadow instead of outer box-shadow for use in containers like toolbars and cards where the outline needs to not bleed outside of its container.

![Screen Shot 2019-10-29 at 11 26 04 AM](https://user-images.githubusercontent.com/175123/67797400-eb0e2580-fa3e-11e9-99da-5d5559ccd2b6.png)