### PR TITLE
Upgrade lerna to 3.18.3 so lockfiles get updated on lerna commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,15 +122,15 @@
       }
     },
     "@lerna/add": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.16.2.tgz",
-      "integrity": "sha512-RAAaF8aODPogj2Ge9Wj3uxPFIBGpog9M+HwSuq03ZnkkO831AmasCTJDqV+GEpl1U2DvnhZQEwHpWmTT0uUeEw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.18.0.tgz",
+      "integrity": "sha512-Z5EaQbBnJn1LEPb0zb0Q2o9T8F8zOnlCsj6JYpY6aSke17UUT7xx0QMN98iBK+ueUHKjN/vdFdYlNCYRSIdujA==",
       "dev": true,
       "requires": {
         "@evocateur/pacote": "^9.6.3",
-        "@lerna/bootstrap": "3.16.2",
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
+        "@lerna/bootstrap": "3.18.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
         "@lerna/npm-conf": "3.16.0",
         "@lerna/validation-error": "3.13.0",
         "dedent": "^0.7.0",
@@ -139,34 +139,23 @@
         "semver": "^6.2.0"
       }
     },
-    "@lerna/batch-packages": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.16.0.tgz",
-      "integrity": "sha512-7AdMkANpubY/FKFI01im01tlx6ygOBJ/0JcixMUWoWP/7Ds3SWQF22ID6fbBr38jUWptYLDs2fagtTDL7YUPuA==",
-      "dev": true,
-      "requires": {
-        "@lerna/package-graph": "3.16.0",
-        "npmlog": "^4.1.2"
-      }
-    },
     "@lerna/bootstrap": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.16.2.tgz",
-      "integrity": "sha512-I+gs7eh6rv9Vyd+CwqL7sftRfOOsSzCle8cv/CGlMN7/p7EAVhxEdAw8SYoHIKHzipXszuqqy1Y3opyleD0qdA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.18.0.tgz",
+      "integrity": "sha512-3DZKWIaKvr7sUImoKqSz6eqn84SsOVMnA5QHwgzXiQjoeZ/5cg9x2r+Xj3+3w/lvLoh0j8U2GNtrIaPNis4bKQ==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "3.16.0",
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
-        "@lerna/has-npm-version": "3.16.0",
-        "@lerna/npm-install": "3.16.0",
-        "@lerna/package-graph": "3.16.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
+        "@lerna/has-npm-version": "3.16.5",
+        "@lerna/npm-install": "3.16.5",
+        "@lerna/package-graph": "3.18.0",
         "@lerna/pulse-till-done": "3.13.0",
-        "@lerna/rimraf-dir": "3.14.2",
+        "@lerna/rimraf-dir": "3.16.5",
         "@lerna/run-lifecycle": "3.16.2",
-        "@lerna/run-parallel-batches": "3.16.0",
-        "@lerna/symlink-binary": "3.16.2",
-        "@lerna/symlink-dependencies": "3.16.2",
+        "@lerna/run-topologically": "3.18.0",
+        "@lerna/symlink-binary": "3.17.0",
+        "@lerna/symlink-dependencies": "3.17.0",
         "@lerna/validation-error": "3.13.0",
         "dedent": "^0.7.0",
         "get-port": "^4.2.0",
@@ -182,33 +171,33 @@
       }
     },
     "@lerna/changed": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.16.4.tgz",
-      "integrity": "sha512-NCD7XkK744T23iW0wqKEgF4R9MYmReUbyHCZKopFnsNpQdqumc3SOIvQUAkKCP6hQJmYvxvOieoVgy/CVDpZ5g==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.18.3.tgz",
+      "integrity": "sha512-xZW7Rm+DlDIGc0EvKGyJZgT9f8FFa4d52mr/Y752dZuXR2qRmf9tXhVloRG39881s2A6yi3jqLtXZggKhsQW4Q==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "3.16.0",
-        "@lerna/command": "3.16.0",
-        "@lerna/listable": "3.16.0",
+        "@lerna/collect-updates": "3.18.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/listable": "3.18.0",
         "@lerna/output": "3.13.0",
-        "@lerna/version": "3.16.4"
+        "@lerna/version": "3.18.3"
       }
     },
     "@lerna/check-working-tree": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.14.2.tgz",
-      "integrity": "sha512-7safqxM/MYoAoxZxulUDtIJIbnBIgo0PB/FHytueG+9VaX7GMnDte2Bt1EKa0dz2sAyQdmQ3Q8ZXpf/6JDjaeg==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.16.5.tgz",
+      "integrity": "sha512-xWjVBcuhvB8+UmCSb5tKVLB5OuzSpw96WEhS2uz6hkWVa/Euh1A0/HJwn2cemyK47wUrCQXtczBUiqnq9yX5VQ==",
       "dev": true,
       "requires": {
-        "@lerna/collect-uncommitted": "3.14.2",
-        "@lerna/describe-ref": "3.14.2",
+        "@lerna/collect-uncommitted": "3.16.5",
+        "@lerna/describe-ref": "3.16.5",
         "@lerna/validation-error": "3.13.0"
       }
     },
     "@lerna/child-process": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.14.2.tgz",
-      "integrity": "sha512-xnq+W5yQb6RkwI0p16ZQnrn6HkloH/MWTw4lGE1nKsBLAUbmSU5oTE93W1nrG0X3IMF/xWc9UYvNdUGMWvZZ4w==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.16.5.tgz",
+      "integrity": "sha512-vdcI7mzei9ERRV4oO8Y1LHBZ3A5+ampRKg1wq5nutLsUA4mEBN6H7JqjWOMY9xZemv6+kATm2ofjJ3lW5TszQg==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.1",
@@ -217,67 +206,67 @@
       }
     },
     "@lerna/clean": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.16.0.tgz",
-      "integrity": "sha512-5P9U5Y19WmYZr7UAMGXBpY7xCRdlR7zhHy8MAPDKVx70rFIBS6nWXn5n7Kntv74g7Lm1gJ2rsiH5tj1OPcRJgg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.18.0.tgz",
+      "integrity": "sha512-BiwBELZNkarRQqj+v5NPB1aIzsOX+Y5jkZ9a5UbwHzEdBUQ5lQa0qaMLSOve/fSkaiZQxe6qnTyatN75lOcDMg==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
         "@lerna/prompt": "3.13.0",
         "@lerna/pulse-till-done": "3.13.0",
-        "@lerna/rimraf-dir": "3.14.2",
+        "@lerna/rimraf-dir": "3.16.5",
         "p-map": "^2.1.0",
         "p-map-series": "^1.0.0",
         "p-waterfall": "^1.0.0"
       }
     },
     "@lerna/cli": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
-      "integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.18.0.tgz",
+      "integrity": "sha512-AwDyfGx7fxJgeaZllEuyJ9LZ6Tdv9yqRD9RX762yCJu+PCAFvB9bp6OYuRSGli7QQgM0CuOYnSg4xVNOmuGKDA==",
       "dev": true,
       "requires": {
         "@lerna/global-options": "3.13.0",
         "dedent": "^0.7.0",
         "npmlog": "^4.1.2",
-        "yargs": "^12.0.1"
+        "yargs": "^14.2.0"
       }
     },
     "@lerna/collect-uncommitted": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.14.2.tgz",
-      "integrity": "sha512-4EkQu4jIOdNL2BMzy/N0ydHB8+Z6syu6xiiKXOoFl0WoWU9H1jEJCX4TH7CmVxXL1+jcs8FIS2pfQz4oew99Eg==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.16.5.tgz",
+      "integrity": "sha512-ZgqnGwpDZiWyzIQVZtQaj9tRizsL4dUOhuOStWgTAw1EMe47cvAY2kL709DzxFhjr6JpJSjXV5rZEAeU3VE0Hg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "chalk": "^2.3.1",
         "figgy-pudding": "^3.5.1",
         "npmlog": "^4.1.2"
       }
     },
     "@lerna/collect-updates": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.16.0.tgz",
-      "integrity": "sha512-HwAIl815X2TNlmcp28zCrSdXfoZWNP7GJPEqNWYk7xDJTYLqQ+SrmKUePjb3AMGBwYAraZSEJLbHdBpJ5+cHmQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.18.0.tgz",
+      "integrity": "sha512-LJMKgWsE/var1RSvpKDIxS8eJ7POADEc0HM3FQiTpEczhP6aZfv9x3wlDjaHpZm9MxJyQilqxZcasRANmRcNgw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/describe-ref": "3.14.2",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/describe-ref": "3.16.5",
         "minimatch": "^3.0.4",
         "npmlog": "^4.1.2",
         "slash": "^2.0.0"
       }
     },
     "@lerna/command": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.16.0.tgz",
-      "integrity": "sha512-u7tE4GC4/gfbPA9eQg+0ulnoJ+PMoMqomx033r/IxqZrHtmJR9+pF/37S0fsxJ2hX/RMFPC7c9Q/i8NEufSpdQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.18.0.tgz",
+      "integrity": "sha512-JQ0TGzuZc9Ky8xtwtSLywuvmkU8X62NTUT3rMNrUykIkOxBaO+tE0O98u2yo/9BYOeTRji9IsjKZEl5i9Qt0xQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/package-graph": "3.16.0",
-        "@lerna/project": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/package-graph": "3.18.0",
+        "@lerna/project": "3.18.0",
         "@lerna/validation-error": "3.13.0",
         "@lerna/write-log-file": "3.13.0",
         "dedent": "^0.7.0",
@@ -307,14 +296,14 @@
       }
     },
     "@lerna/create": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.16.0.tgz",
-      "integrity": "sha512-OZApR1Iz7awutbmj4sAArwhqCyKgcrnw9rH0aWAUrkYWrD1w4TwkvAcYAsfx5GpQGbLQwoXhoyyPwPfZRRWz3Q==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.18.0.tgz",
+      "integrity": "sha512-y9oS7ND5T13c+cCTJHa2Y9in02ppzyjsNynVWFuS40eIzZ3z058d9+3qSBt1nkbbQlVyfLoP6+bZPsjyzap5ig==",
       "dev": true,
       "requires": {
         "@evocateur/pacote": "^9.6.3",
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
         "@lerna/npm-conf": "3.16.0",
         "@lerna/validation-error": "3.13.0",
         "camelcase": "^5.0.0",
@@ -352,56 +341,58 @@
       }
     },
     "@lerna/describe-ref": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.14.2.tgz",
-      "integrity": "sha512-qa5pzDRK2oBQXNjyRmRnN7E8a78NMYfQjjlRFB0KNHMsT6mCiL9+8kIS39sSE2NqT8p7xVNo2r2KAS8R/m3CoQ==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.16.5.tgz",
+      "integrity": "sha512-c01+4gUF0saOOtDBzbLMFOTJDHTKbDFNErEY6q6i9QaXuzy9LNN62z+Hw4acAAZuJQhrVWncVathcmkkjvSVGw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "npmlog": "^4.1.2"
       }
     },
     "@lerna/diff": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.16.0.tgz",
-      "integrity": "sha512-QUpVs5TPl8vBIne10/vyjUxanQBQQp7Lk3iaB8MnCysKr0O+oy7trWeFVDPEkBTCD177By7yPGyW5Yey1nCBbA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.18.0.tgz",
+      "integrity": "sha512-3iLNlpurc2nV9k22w8ini2Zjm2UPo3xtQgWyqdA6eJjvge0+5AlNAWfPoV6cV+Hc1xDbJD2YDSFpZPJ1ZGilRw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
         "@lerna/validation-error": "3.13.0",
         "npmlog": "^4.1.2"
       }
     },
     "@lerna/exec": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.16.0.tgz",
-      "integrity": "sha512-mH3O5NXf/O88jBaBBTUf+d56CUkxpg782s3Jxy7HWbVuSUULt3iMRPTh+zEXO5/555etsIVVDDyUR76meklrJA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.18.0.tgz",
+      "integrity": "sha512-hwkuzg1+38+pbzdZPhGtLIYJ59z498/BCNzR8d4/nfMYm8lFbw9RgJJajLcdbuJ9LJ08cZ93hf8OlzetL84TYg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
-        "@lerna/run-topologically": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
+        "@lerna/run-topologically": "3.18.0",
         "@lerna/validation-error": "3.13.0",
         "p-map": "^2.1.0"
       }
     },
     "@lerna/filter-options": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.16.0.tgz",
-      "integrity": "sha512-InIi1fF8+PxpCwir9bIy+pGxrdE6hvN0enIs1eNGCVS1TTE8osNgiZXa838bMQ1yaEccdcnVX6Z03BNKd56kNg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.18.0.tgz",
+      "integrity": "sha512-UGVcixs3TGzD8XSmFSbwUVVQnAjaZ6Rmt8Vuq2RcR98ULkGB1LiGNMY89XaNBhaaA8vx7yQWiLmJi2AfmD63Qg==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "3.16.0",
-        "@lerna/filter-packages": "3.16.0",
-        "dedent": "^0.7.0"
+        "@lerna/collect-updates": "3.18.0",
+        "@lerna/filter-packages": "3.18.0",
+        "dedent": "^0.7.0",
+        "figgy-pudding": "^3.5.1",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/filter-packages": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.16.0.tgz",
-      "integrity": "sha512-eGFzQTx0ogkGDCnbTuXqssryR6ilp8+dcXt6B+aq1MaqL/vOJRZyqMm4TY3CUOUnzZCi9S2WWyMw3PnAJOF+kg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.18.0.tgz",
+      "integrity": "sha512-6/0pMM04bCHNATIOkouuYmPg6KH3VkPCIgTfQmdkPJTullERyEQfNUKikrefjxo1vHOoCACDpy65JYyKiAbdwQ==",
       "dev": true,
       "requires": {
         "@lerna/validation-error": "3.13.0",
@@ -430,12 +421,12 @@
       }
     },
     "@lerna/github-client": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.16.0.tgz",
-      "integrity": "sha512-IVJjcKjkYaUEPJsDyAblHGEFFNKCRyMagbIDm14L7Ab94ccN6i4TKOqAFEJn2SJHYvKKBdp3Zj2zNlASOMe3DA==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.16.5.tgz",
+      "integrity": "sha512-rHQdn8Dv/CJrO3VouOP66zAcJzrHsm+wFuZ4uGAai2At2NkgKH+tpNhQy2H1PSC0Ezj9LxvdaHYrUzULqVK5Hw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "@octokit/plugin-enterprise-rest": "^3.6.1",
         "@octokit/rest": "^16.28.4",
         "git-url-parse": "^11.1.2",
@@ -460,23 +451,23 @@
       "dev": true
     },
     "@lerna/has-npm-version": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.16.0.tgz",
-      "integrity": "sha512-TIY036dA9J8OyTrZq9J+it2DVKifL65k7hK8HhkUPpitJkw6jwbMObA/8D40LOGgWNPweJWqmlrTbRSwsR7DrQ==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.16.5.tgz",
+      "integrity": "sha512-WL7LycR9bkftyqbYop5rEGJ9sRFIV55tSGmbN1HLrF9idwOCD7CLrT64t235t3t4O5gehDnwKI5h2U3oxTrF8Q==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "semver": "^6.2.0"
       }
     },
     "@lerna/import": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.16.0.tgz",
-      "integrity": "sha512-trsOmGHzw0rL/f8BLNvd+9PjoTkXq2Dt4/V2UCha254hMQaYutbxcYu8iKPxz9x86jSPlH7FpbTkkHXDsoY7Yg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.18.0.tgz",
+      "integrity": "sha512-2pYIkkBTZsEdccfc+dPsKZeSw3tBzKSyl0b2lGrfmNX2Y41qqOzsJCyI1WO1uvEIP8aOaLy4hPpqRIBe4ee7hw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
         "@lerna/prompt": "3.13.0",
         "@lerna/pulse-till-done": "3.13.0",
         "@lerna/validation-error": "3.13.0",
@@ -486,50 +477,50 @@
       }
     },
     "@lerna/init": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.16.0.tgz",
-      "integrity": "sha512-Ybol/x5xMtBgokx4j7/Y3u0ZmNh0NiSWzBFVaOs2NOJKvuqrWimF67DKVz7yYtTYEjtaMdug64ohFF4jcT/iag==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.18.0.tgz",
+      "integrity": "sha512-/vHpmXkMlSaJaq25v5K13mcs/2L7E32O6dSsEkHaZCDRiV2BOqsZng9jjbE/4ynfsWfLLlU9ZcydwG72C3I+mQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
-        "@lerna/command": "3.16.0",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/command": "3.18.0",
         "fs-extra": "^8.1.0",
         "p-map": "^2.1.0",
         "write-json-file": "^3.2.0"
       }
     },
     "@lerna/link": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.16.2.tgz",
-      "integrity": "sha512-eCPg5Lo8HT525fIivNoYF3vWghO3UgEVFdbsiPmhzwI7IQyZro5HWYzLtywSAdEog5XZpd2Bbn0CsoHWBB3gww==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.18.0.tgz",
+      "integrity": "sha512-FbbIpH0EpsC+dpAbvxCoF3cn7F1MAyJjEa5Lh3XkDGATOlinMFuKCbmX0NLpOPQZ5zghvrui97cx+jz5F2IlHw==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.16.0",
-        "@lerna/package-graph": "3.16.0",
-        "@lerna/symlink-dependencies": "3.16.2",
+        "@lerna/command": "3.18.0",
+        "@lerna/package-graph": "3.18.0",
+        "@lerna/symlink-dependencies": "3.17.0",
         "p-map": "^2.1.0",
         "slash": "^2.0.0"
       }
     },
     "@lerna/list": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.16.0.tgz",
-      "integrity": "sha512-TkvstoPsgKqqQ0KfRumpsdMXfRSEhdXqOLq519XyI5IRWYxhoqXqfi8gG37UoBPhBNoe64japn5OjphF3rOmQA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.18.0.tgz",
+      "integrity": "sha512-mpB7Q6T+n2CaiPFz0LuOE+rXphDfHm0mKIwShnyS/XDcii8jXv+z9Iytj8p3rfCH2I1L80j2qL6jWzyGy/uzKA==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
-        "@lerna/listable": "3.16.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
+        "@lerna/listable": "3.18.0",
         "@lerna/output": "3.13.0"
       }
     },
     "@lerna/listable": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.16.0.tgz",
-      "integrity": "sha512-mtdAT2EEECqrJSDm/aXlOUFr1MRE4p6hppzY//Klp05CogQy6uGaKk+iKG5yyCLaOXFFZvG4HfO11CmoGSDWzw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.18.0.tgz",
+      "integrity": "sha512-9gLGKYNLSKeurD+sJ2RA+nz4Ftulr91U127gefz0RlmAPpYSjwcJkxwa0UfJvpQTXv9C7yzHLnn0BjyAQRjuew==",
       "dev": true,
       "requires": {
-        "@lerna/query-graph": "3.16.0",
+        "@lerna/query-graph": "3.18.0",
         "chalk": "^2.3.1",
         "columnify": "^1.5.4"
       }
@@ -557,9 +548,9 @@
       }
     },
     "@lerna/npm-dist-tag": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.16.0.tgz",
-      "integrity": "sha512-MQrBkqJJB9+eNphuj9w90QPMOs4NQXMuSRk9NqzeFunOmdDopPCV0Q7IThSxEuWnhJ2n3B7G0vWUP7tNMPdqIQ==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.18.1.tgz",
+      "integrity": "sha512-vWkZh2T/O9OjPLDrba0BTWO7ug/C3sCwjw7Qyk1aEbxMBXB/eEJPqirwJTWT+EtRJQYB01ky3K8ZFOhElVyjLw==",
       "dev": true,
       "requires": {
         "@evocateur/npm-registry-fetch": "^4.0.0",
@@ -570,12 +561,12 @@
       }
     },
     "@lerna/npm-install": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.16.0.tgz",
-      "integrity": "sha512-APUOIilZCzDzce92uLEwzt1r7AEMKT/hWA1ThGJL+PO9Rn8A95Km3o2XZAYG4W0hR+P4O2nSVuKbsjQtz8CjFQ==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.16.5.tgz",
+      "integrity": "sha512-hfiKk8Eku6rB9uApqsalHHTHY+mOrrHeWEs+gtg7+meQZMTS3kzv4oVp5cBZigndQr3knTLjwthT/FX4KvseFg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "@lerna/get-npm-exec-opts": "3.13.0",
         "fs-extra": "^8.1.0",
         "npm-package-arg": "^6.1.0",
@@ -602,12 +593,12 @@
       }
     },
     "@lerna/npm-run-script": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.14.2.tgz",
-      "integrity": "sha512-LbVFv+nvAoRTYLMrJlJ8RiakHXrLslL7Jp/m1R18vYrB8LYWA3ey+nz5Tel2OELzmjUiemAKZsD9h6i+Re5egg==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.16.5.tgz",
+      "integrity": "sha512-1asRi+LjmVn3pMjEdpqKJZFT/3ZNpb+VVeJMwrJaV/3DivdNg7XlPK9LTrORuKU4PSvhdEZvJmSlxCKyDpiXsQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "@lerna/get-npm-exec-opts": "3.13.0",
         "npmlog": "^4.1.2"
       }
@@ -659,9 +650,9 @@
       }
     },
     "@lerna/package-graph": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.16.0.tgz",
-      "integrity": "sha512-A2mum/gNbv7zCtAwJqoxzqv89As73OQNK2MgSX1SHWya46qoxO9a9Z2c5lOFQ8UFN5ZxqWMfFYXRCz7qzwmFXw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.18.0.tgz",
+      "integrity": "sha512-BLYDHO5ihPh20i3zoXfLZ5ZWDCrPuGANgVhl7k5pCmRj90LCvT+C7V3zrw70fErGAfvkcYepMqxD+oBrAYwquQ==",
       "dev": true,
       "requires": {
         "@lerna/prerelease-id-from-version": "3.16.0",
@@ -681,9 +672,9 @@
       }
     },
     "@lerna/project": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.16.0.tgz",
-      "integrity": "sha512-NrKcKK1EqXqhrGvslz6Q36+ZHuK3zlDhGdghRqnxDcHxMPT01NgLcmsnymmQ+gjMljuLRmvKYYCuHrknzX8VrA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.18.0.tgz",
+      "integrity": "sha512-+LDwvdAp0BurOAWmeHE3uuticsq9hNxBI0+FMHiIai8jrygpJGahaQrBYWpwbshbQyVLeQgx3+YJdW2TbEdFWA==",
       "dev": true,
       "requires": {
         "@lerna/package": "3.16.0",
@@ -711,22 +702,22 @@
       }
     },
     "@lerna/publish": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.16.4.tgz",
-      "integrity": "sha512-XZY+gRuF7/v6PDQwl7lvZaGWs8CnX6WIPIu+OCcyFPSL/rdWegdN7HieKBHskgX798qRQc2GrveaY7bNoTKXAw==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.18.3.tgz",
+      "integrity": "sha512-XlfWOWIhaSK0Y2sX5ppNWI5Y3CDtlxMcQa1hTbZlC5rrDA6vD32iutbmH6Ix3c6wtvVbSkgA39GWsQEXxPS+7w==",
       "dev": true,
       "requires": {
         "@evocateur/libnpmaccess": "^3.1.2",
         "@evocateur/npm-registry-fetch": "^4.0.0",
         "@evocateur/pacote": "^9.6.3",
-        "@lerna/check-working-tree": "3.14.2",
-        "@lerna/child-process": "3.14.2",
-        "@lerna/collect-updates": "3.16.0",
-        "@lerna/command": "3.16.0",
-        "@lerna/describe-ref": "3.14.2",
+        "@lerna/check-working-tree": "3.16.5",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/collect-updates": "3.18.0",
+        "@lerna/command": "3.18.0",
+        "@lerna/describe-ref": "3.16.5",
         "@lerna/log-packed": "3.16.0",
         "@lerna/npm-conf": "3.16.0",
-        "@lerna/npm-dist-tag": "3.16.0",
+        "@lerna/npm-dist-tag": "3.18.1",
         "@lerna/npm-publish": "3.16.2",
         "@lerna/otplease": "3.16.0",
         "@lerna/output": "3.13.0",
@@ -735,9 +726,9 @@
         "@lerna/prompt": "3.13.0",
         "@lerna/pulse-till-done": "3.13.0",
         "@lerna/run-lifecycle": "3.16.2",
-        "@lerna/run-topologically": "3.16.0",
+        "@lerna/run-topologically": "3.18.0",
         "@lerna/validation-error": "3.13.0",
-        "@lerna/version": "3.16.4",
+        "@lerna/version": "3.18.3",
         "figgy-pudding": "^3.5.1",
         "fs-extra": "^8.1.0",
         "npm-package-arg": "^6.1.0",
@@ -758,12 +749,12 @@
       }
     },
     "@lerna/query-graph": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.16.0.tgz",
-      "integrity": "sha512-p0RO+xmHDO95ChJdWkcy9TNLysLkoDARXeRHzY5U54VCwl3Ot/2q8fMCVlA5UeGXDutEyyByl3URqEpcQCWI7Q==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.18.0.tgz",
+      "integrity": "sha512-fgUhLx6V0jDuKZaKj562jkuuhrfVcjl5sscdfttJ8dXNVADfDz76nzzwLY0ZU7/0m69jDedohn5Fx5p7hDEVEg==",
       "dev": true,
       "requires": {
-        "@lerna/package-graph": "3.16.0",
+        "@lerna/package-graph": "3.18.0",
         "figgy-pudding": "^3.5.1"
       }
     },
@@ -779,28 +770,28 @@
       }
     },
     "@lerna/rimraf-dir": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.14.2.tgz",
-      "integrity": "sha512-eFNkZsy44Bu9v1Hrj5Zk6omzg8O9h/7W6QYK1TTUHeyrjTEwytaNQlqF0lrTLmEvq55sviV42NC/8P3M2cvq8Q==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.16.5.tgz",
+      "integrity": "sha512-bQlKmO0pXUsXoF8lOLknhyQjOZsCc0bosQDoX4lujBXSWxHVTg1VxURtWf2lUjz/ACsJVDfvHZbDm8kyBk5okA==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "3.14.2",
+        "@lerna/child-process": "3.16.5",
         "npmlog": "^4.1.2",
         "path-exists": "^3.0.0",
         "rimraf": "^2.6.2"
       }
     },
     "@lerna/run": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.16.0.tgz",
-      "integrity": "sha512-woTeLlB1OAAz4zzjdI6RyIxSGuxiUPHJZm89E1pDEPoWwtQV6HMdMgrsQd9ATsJ5Ez280HH4bF/LStAlqW8Ufg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.18.0.tgz",
+      "integrity": "sha512-sblxHBZ9djaaG7wefPcfEicDqzrB7CP1m/jIB0JvPEQwG4C2qp++ewBpkjRw/mBtjtzg0t7v0nNMXzaWYrQckQ==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.16.0",
-        "@lerna/filter-options": "3.16.0",
-        "@lerna/npm-run-script": "3.14.2",
+        "@lerna/command": "3.18.0",
+        "@lerna/filter-options": "3.18.0",
+        "@lerna/npm-run-script": "3.16.5",
         "@lerna/output": "3.13.0",
-        "@lerna/run-topologically": "3.16.0",
+        "@lerna/run-topologically": "3.18.0",
         "@lerna/timer": "3.13.0",
         "@lerna/validation-error": "3.13.0",
         "p-map": "^2.1.0"
@@ -818,31 +809,21 @@
         "npmlog": "^4.1.2"
       }
     },
-    "@lerna/run-parallel-batches": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.16.0.tgz",
-      "integrity": "sha512-2J/Nyv+MvogmQEfC7VcS21ifk7w0HVvzo2yOZRPvkCzGRu/rducxtB4RTcr58XCZ8h/Bt1aqQYKExu3c/3GXwg==",
-      "dev": true,
-      "requires": {
-        "p-map": "^2.1.0",
-        "p-map-series": "^1.0.0"
-      }
-    },
     "@lerna/run-topologically": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.16.0.tgz",
-      "integrity": "sha512-4Hlpv4zDtKWa5Z0tPkeu0sK+bxZEKgkNESMGmWrUCNfj7xwvAJurcraK8+a2Y0TFYwf0qjSLY/MzX+ZbJA3Cgw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.18.0.tgz",
+      "integrity": "sha512-lrfEewwuUMC3ioxf9Z9NdHUakN6ihekcPfdYbzR2slmdbjYKmIA5srkWdrK8NwOpQCAuekpOovH2s8X3FGEopg==",
       "dev": true,
       "requires": {
-        "@lerna/query-graph": "3.16.0",
+        "@lerna/query-graph": "3.18.0",
         "figgy-pudding": "^3.5.1",
         "p-queue": "^4.0.0"
       }
     },
     "@lerna/symlink-binary": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.16.2.tgz",
-      "integrity": "sha512-kz9XVoFOGSF83gg4gBqH+mG6uxfJfTp8Uy+Cam40CvMiuzfODrGkjuBEFoM/uO2QOAwZvbQDYOBpKUa9ZxHS1Q==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.17.0.tgz",
+      "integrity": "sha512-RLpy9UY6+3nT5J+5jkM5MZyMmjNHxZIZvXLV+Q3MXrf7Eaa1hNqyynyj4RO95fxbS+EZc4XVSk25DGFQbcRNSQ==",
       "dev": true,
       "requires": {
         "@lerna/create-symlink": "3.16.2",
@@ -852,14 +833,14 @@
       }
     },
     "@lerna/symlink-dependencies": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.16.2.tgz",
-      "integrity": "sha512-wnZqGJQ+Jvr1I3inxrkffrFZfmQI7Ta8gySw/UWCy95QtZWF/f5yk8zVIocCAsjzD0wgb3jJE3CFJ9W5iwWk1A==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.17.0.tgz",
+      "integrity": "sha512-KmjU5YT1bpt6coOmdFueTJ7DFJL4H1w5eF8yAQ2zsGNTtZ+i5SGFBWpb9AQaw168dydc3s4eu0W0Sirda+F59Q==",
       "dev": true,
       "requires": {
         "@lerna/create-symlink": "3.16.2",
         "@lerna/resolve-symlink": "3.16.0",
-        "@lerna/symlink-binary": "3.16.2",
+        "@lerna/symlink-binary": "3.17.0",
         "fs-extra": "^8.1.0",
         "p-finally": "^1.0.0",
         "p-map": "^2.1.0",
@@ -882,26 +863,27 @@
       }
     },
     "@lerna/version": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.16.4.tgz",
-      "integrity": "sha512-ikhbMeIn5ljCtWTlHDzO4YvTmpGTX1lWFFIZ79Vd1TNyOr+OUuKLo/+p06mCl2WEdZu0W2s5E9oxfAAQbyDxEg==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.18.3.tgz",
+      "integrity": "sha512-IXXRlyM3Q/jrc+QZio+bgjG4ZaK+4LYmY4Yql1xyY0wZhAKsWP/Q6ho7e1EJNjNC5dUJO99Fq7qB05MkDf2OcQ==",
       "dev": true,
       "requires": {
-        "@lerna/check-working-tree": "3.14.2",
-        "@lerna/child-process": "3.14.2",
-        "@lerna/collect-updates": "3.16.0",
-        "@lerna/command": "3.16.0",
+        "@lerna/check-working-tree": "3.16.5",
+        "@lerna/child-process": "3.16.5",
+        "@lerna/collect-updates": "3.18.0",
+        "@lerna/command": "3.18.0",
         "@lerna/conventional-commits": "3.16.4",
-        "@lerna/github-client": "3.16.0",
+        "@lerna/github-client": "3.16.5",
         "@lerna/gitlab-client": "3.15.0",
         "@lerna/output": "3.13.0",
         "@lerna/prerelease-id-from-version": "3.16.0",
         "@lerna/prompt": "3.13.0",
         "@lerna/run-lifecycle": "3.16.2",
-        "@lerna/run-topologically": "3.16.0",
+        "@lerna/run-topologically": "3.18.0",
         "@lerna/validation-error": "3.13.0",
         "chalk": "^2.3.1",
         "dedent": "^0.7.0",
+        "load-json-file": "^5.3.0",
         "minimatch": "^3.0.4",
         "npmlog": "^4.1.2",
         "p-map": "^2.1.0",
@@ -910,7 +892,8 @@
         "p-waterfall": "^1.0.0",
         "semver": "^6.2.0",
         "slash": "^2.0.0",
-        "temp-write": "^3.4.0"
+        "temp-write": "^3.4.0",
+        "write-json-file": "^3.2.0"
       }
     },
     "@lerna/write-log-file": {
@@ -940,11 +923,12 @@
       "dev": true
     },
     "@octokit/endpoint": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.3.6.tgz",
-      "integrity": "sha512-XuerByak8H+jW9J/rVMEdBXfI4UTsDWUwAKgIP/uhQjXIUVdPRwt2Zg+SmbWQ+WY7pRkw/hFVES8C4G/Kle7oA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.0.tgz",
+      "integrity": "sha512-TXYS6zXeBImNB9BVj+LneMDqXX+H0exkOpyXobvp92O3B1348QsKnNioISFKgOMsb3ibZvQGwCdpiwQd3KAjIA==",
       "dev": true,
       "requires": {
+        "@octokit/types": "^1.0.0",
         "is-plain-object": "^3.0.0",
         "universal-user-agent": "^4.0.0"
       },
@@ -973,13 +957,14 @@
       "dev": true
     },
     "@octokit/request": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.1.0.tgz",
-      "integrity": "sha512-I15T9PwjFs4tbWyhtFU2Kq7WDPidYMvRB7spmxoQRZfxSmiqullG+Nz+KbSmpkfnlvHwTr1e31R5WReFRKMXjg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.0.tgz",
+      "integrity": "sha512-mMIeNrtYyNEIYNsKivDyUAukBkw0M5ckyJX56xoFRXSasDPCloIXaQOnaKNopzQ8dIOvpdq1ma8gmrS+h6O2OQ==",
       "dev": true,
       "requires": {
-        "@octokit/endpoint": "^5.1.0",
+        "@octokit/endpoint": "^5.5.0",
         "@octokit/request-error": "^1.0.1",
+        "@octokit/types": "^1.0.0",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
@@ -1015,12 +1000,12 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.30.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.30.1.tgz",
-      "integrity": "sha512-1n2QzTbbaBXNLpx7WHlcsSMdJvxSdKmerXQm+bMYlKDbQM19uq446ZpGs7Ynq5SsdLj1usIfgJ9gJf4LtcWkDw==",
+      "version": "16.34.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.34.1.tgz",
+      "integrity": "sha512-JUoS12cdktf1fv86rgrjC/RvYLuL+o7p57W7zX1x7ANFJ7OvdV8emvUNkFlcidEaOkYrxK3SoWgQFt3FhNmabA==",
       "dev": true,
       "requires": {
-        "@octokit/request": "^5.0.0",
+        "@octokit/request": "^5.2.0",
         "@octokit/request-error": "^1.0.2",
         "atob-lite": "^2.0.0",
         "before-after-hook": "^2.0.0",
@@ -1032,6 +1017,15 @@
         "octokit-pagination-methods": "^1.1.0",
         "once": "^1.4.0",
         "universal-user-agent": "^4.0.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-t4ZD74UnNVMq6kZBDZceflRKK3q4o5PoCKMAGht0RK84W57tqonqKL3vCxJHtbGExdan9RwV8r7VJBZxIM1O7Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^12.11.1"
       }
     },
     "@types/events": {
@@ -1058,9 +1052,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.9.tgz",
-      "integrity": "sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ==",
+      "version": "12.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.3.tgz",
+      "integrity": "sha512-opgSsy+cEF9N8MgaVPnWVtdJ3o4mV2aMHvDq7thkQUFt0EuOHJon4rQpJfhjmNHB+ikl0Cd6WhWIErOyQ+f7tw==",
       "dev": true
     },
     "@zkochan/cmd-shim": {
@@ -1369,9 +1363,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-      "integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
       "dev": true
     },
     "brace-expansion": {
@@ -1604,20 +1598,20 @@
       "dev": true
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -1627,22 +1621,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1704,9 +1699,9 @@
       }
     },
     "commander": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
-      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "optional": true
     },
@@ -1772,9 +1767,9 @@
       "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
-      "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.5.tgz",
+      "integrity": "sha512-RrkdWnL/TVyWV1ayWmSsrWorsTDqjL/VwG5ZSEneBQrd65ONcfeA1cW7FLtNweQyMiKOyriCMTKRSlk18DjTrw==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
@@ -1820,15 +1815,15 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.7.tgz",
-      "integrity": "sha512-p/wzs9eYaxhFbrmX/mCJNwJuvvHR+j4Fd0SQa2xyAhYed6KBiZ780LvoqUUvsayP4R1DtC27czalGUhKV2oabw==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.9.tgz",
+      "integrity": "sha512-2Y3QfiAM37WvDMjkVNaRtZgxVzWKj73HE61YQ/95T53yle+CRwTVSl6Gbv/lWVKXeZcM5af9n9TDVf0k7Xh+cw==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
         "conventional-commits-filter": "^2.0.2",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.1.2",
+        "handlebars": "^4.4.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.2.1",
         "meow": "^4.0.0",
@@ -1859,9 +1854,9 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz",
-      "integrity": "sha512-KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.5.tgz",
+      "integrity": "sha512-qVz9+5JwdJzsbt7JbJ6P7NOXBGt8CyLFJYSjKAuPSgO+5UGfcsbk9EMR+lI8Unlvx6qwIc2YDJlrGIfay2ehNA==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
@@ -2221,6 +2216,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
@@ -2261,9 +2262,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
-      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+      "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
@@ -2274,8 +2275,8 @@
         "is-regex": "^1.0.4",
         "object-inspect": "^1.6.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       }
     },
     "es-to-primitive": {
@@ -2711,9 +2712,9 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-pkg-repo": {
@@ -3005,9 +3006,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -3050,15 +3051,15 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
-      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -3151,9 +3152,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "http-cache-semantics": {
@@ -3184,9 +3185,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
@@ -3224,9 +3225,9 @@
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.2.tgz",
-      "integrity": "sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -3396,12 +3397,6 @@
           }
         }
       }
-    },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -3750,36 +3745,27 @@
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^2.0.0"
-      }
-    },
     "lerna": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.16.4.tgz",
-      "integrity": "sha512-0HfwXIkqe72lBLZcNO9NMRfylh5Ng1l8tETgYQ260ZdHRbPuaLKE3Wqnd2YYRRkWfwPyEyZO8mZweBR+slVe1A==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.18.3.tgz",
+      "integrity": "sha512-Bnr/RjyDSVA2Vu+NArK7do4UIpyy+EShOON7tignfAekPbi7cNDnMMGgSmbCQdKITkqPACMfCMdyq0hJlg6n3g==",
       "dev": true,
       "requires": {
-        "@lerna/add": "3.16.2",
-        "@lerna/bootstrap": "3.16.2",
-        "@lerna/changed": "3.16.4",
-        "@lerna/clean": "3.16.0",
-        "@lerna/cli": "3.13.0",
-        "@lerna/create": "3.16.0",
-        "@lerna/diff": "3.16.0",
-        "@lerna/exec": "3.16.0",
-        "@lerna/import": "3.16.0",
-        "@lerna/init": "3.16.0",
-        "@lerna/link": "3.16.2",
-        "@lerna/list": "3.16.0",
-        "@lerna/publish": "3.16.4",
-        "@lerna/run": "3.16.0",
-        "@lerna/version": "3.16.4",
+        "@lerna/add": "3.18.0",
+        "@lerna/bootstrap": "3.18.0",
+        "@lerna/changed": "3.18.3",
+        "@lerna/clean": "3.18.0",
+        "@lerna/cli": "3.18.0",
+        "@lerna/create": "3.18.0",
+        "@lerna/diff": "3.18.0",
+        "@lerna/exec": "3.18.0",
+        "@lerna/import": "3.18.0",
+        "@lerna/init": "3.18.0",
+        "@lerna/link": "3.18.0",
+        "@lerna/list": "3.18.0",
+        "@lerna/publish": "3.18.3",
+        "@lerna/run": "3.18.0",
+        "@lerna/version": "3.18.3",
         "import-local": "^2.0.0",
         "npmlog": "^4.1.2"
       }
@@ -3917,31 +3903,22 @@
       }
     },
     "make-fetch-happen": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz",
-      "integrity": "sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.1.tgz",
+      "integrity": "sha512-b4dfaMvUDR67zxUq1+GN7Ke9rH5WvGRmoHuMH7l+gmUCR2tCXFP6mpeJ9Dp+jB6z8mShRopSf1vLRBhRs8Cu5w==",
       "dev": true,
       "requires": {
         "agentkeepalive": "^3.4.1",
         "cacache": "^12.0.0",
         "http-cache-semantics": "^3.8.1",
         "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
+        "https-proxy-agent": "^2.2.3",
         "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "node-fetch-npm": "^2.0.2",
         "promise-retry": "^1.1.1",
         "socks-proxy-agent": "^4.0.0",
         "ssri": "^6.0.0"
-      }
-    },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -3963,25 +3940,6 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "mem": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
-        }
       }
     },
     "meow": {
@@ -4262,9 +4220,9 @@
       }
     },
     "node-gyp": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.4.tgz",
-      "integrity": "sha512-PMYap4ekQckQDZ2lxoORUF/nX13haU1JdCAlmLgvrykLyN0LFkhfwPbWhYjTxwTruCWbTkeOxFo043kjhmKHZA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.5.tgz",
+      "integrity": "sha512-WABl9s4/mqQdZneZHVWVG4TVr6QQJZUC6PAx47ITSk9lreZ1n+7Z9mMAIbA3vnO4J9W20P7LhCxtzfWsAD/KDw==",
       "dev": true,
       "requires": {
         "env-paths": "^1.0.0",
@@ -4366,9 +4324,9 @@
       }
     },
     "npm-packlist": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
-      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.6.tgz",
+      "integrity": "sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==",
       "dev": true,
       "requires": {
         "ignore-walk": "^3.0.1",
@@ -4544,17 +4502,6 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -4581,22 +4528,10 @@
         "os-tmpdir": "^1.0.0"
       }
     },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
     },
     "p-limit": {
@@ -5174,9 +5109,9 @@
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "resolve": {
@@ -5995,13 +5930,13 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.5.tgz",
+      "integrity": "sha512-7L3W+Npia1OCr5Blp4/Vw83tK1mu5gnoIURtT1fUVfQ3Kf8WStWV6NJz0fdoBJZls0KlweruRTLVe6XLafmy5g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
@@ -6199,9 +6134,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-      "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -6249,13 +6184,48 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "wrappy": {
@@ -6358,29 +6328,28 @@
       "dev": true
     },
     "yargs": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
+      "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
+        "cliui": "^5.0.0",
         "decamelize": "^1.2.0",
         "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
+        "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
+        "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
+        "string-width": "^3.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
+        "y18n": "^4.0.0",
+        "yargs-parser": "^15.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "find-up": {
@@ -6433,30 +6402,31 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
     },
     "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   },
   "devDependencies": {
     "@babel/preset-stage-2": "^7.0.0",
-    "lerna": "^3.13.4"
+    "lerna": "^3.18.3"
   }
 }


### PR DESCRIPTION
Lerna v3.18.2 has a bug fix to "Update lockfile version, if present (lerna/lerna@5b1b40b)". My hope is that this reduces the need for PRs like #160.