### PR TITLE
PDS-393: Fixed Input over extending bounding box.

### DIFF
--- a/packages/react-components/source/scss/library/components/forms/_input.scss
+++ b/packages/react-components/source/scss/library/components/forms/_input.scss
@@ -7,6 +7,7 @@
   outline: none;
   padding: 5px 7px;
   width: 100%;
+  box-sizing: border-box;
 
   &.rc-input-empty,
   &::placeholder {


### PR DESCRIPTION
Before this commit, the Input react component would, by default, over
extend its bounding box. Now, it will fit appropriately.

Note: I did not set up a test environment to validate the fix, but it did solve the issue when applied in Chrome's css dev tools. 

Original issue:
![before-fix](https://user-images.githubusercontent.com/8687939/68042662-aaa5e600-fc90-11e9-96bf-1fef0cf46ef5.png)

After fix:
![after fix](https://user-images.githubusercontent.com/8687939/68042661-aaa5e600-fc90-11e9-8715-10738254d57a.png)
