### PR TITLE
Allow menu list for selects to expand to their intrinsic width

### DIFF
--- a/packages/react-components/source/react/helpers/statics.js
+++ b/packages/react-components/source/react/helpers/statics.js
@@ -85,21 +85,21 @@ const getDropdownPosition = (target, anchor, margin) => {
       return {
         top: height + margin,
         right: 0,
-        width,
+        minWidth: width,
       };
     }
     case 'top right': {
       return {
         bottom: height + margin,
         right: 0,
-        width,
+        minWidth: width,
       };
     }
     case 'top left': {
       return {
         bottom: height + margin,
         left: 0,
-        width,
+        minWidth: width,
       };
     }
     default:
@@ -107,7 +107,7 @@ const getDropdownPosition = (target, anchor, margin) => {
       return {
         top: height + margin,
         left: 0,
-        width,
+        minWidth: width,
       };
     }
   }

--- a/packages/react-components/source/scss/library/components/_action-select.scss
+++ b/packages/react-components/source/scss/library/components/_action-select.scss
@@ -2,7 +2,7 @@
   position: relative;
 
   .rc-menu-list {
-    min-width: 150px;
+    box-sizing: border-box;
     position: absolute;
     z-index: 10;
   }

--- a/packages/react-components/source/scss/library/components/_button-select.scss
+++ b/packages/react-components/source/scss/library/components/_button-select.scss
@@ -6,7 +6,7 @@
   }
 
   .rc-menu-list {
-    min-width: 150px;
+    box-sizing: border-box;
     position: absolute;
     z-index: 10;
   }

--- a/packages/react-components/source/scss/library/components/forms/_select.scss
+++ b/packages/react-components/source/scss/library/components/forms/_select.scss
@@ -14,7 +14,7 @@
   }
 
   .rc-menu-list {
-    min-width: 150px;
+    box-sizing: border-box;
     position: absolute;
     z-index: 10;
   }


### PR DESCRIPTION
Resolves [PDS-353](https://tickets.puppetlabs.com/browse/PDS-353)

This applies to Select, ActionSelect, and ButtonSelect, and maintains the original intent of the width of dropdown based on width of button, which was to make wide buttons result in matching wide dropdowns.

![Screen Shot 2019-11-06 at 7 38 00 AM](https://user-images.githubusercontent.com/175123/68313297-2b862880-0069-11ea-972c-d6bfb6052396.png)