### PR TITLE
Place Card.Title and Card.Action in flexbox header

### DIFF
--- a/packages/react-components/source/react/library/card/Card.js
+++ b/packages/react-components/source/react/library/card/Card.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { elementElevation } from '../../helpers/customPropTypes';
@@ -52,6 +52,25 @@ const Card = ({
 }) => {
   const Element = assignDefaultElement(as, selectable);
 
+  // Find title and actions for placement in header
+  const childrenArray = Children.toArray(children);
+  const title = childrenArray.find(
+    child => child.type && child.type.name === 'CardTitle',
+  );
+  const actions = childrenArray.find(
+    child =>
+      child.type &&
+      (child.type.name === 'CardAction' ||
+        child.type.name === 'CardActionSelect'),
+  );
+  const otherChildren = childrenArray.filter(
+    child =>
+      child.type &&
+      child.type.name !== 'CardTitle' &&
+      child.type.name !== 'CardAction' &&
+      child.type.name !== 'CardActionSelect',
+  );
+
   return (
     <Element
       className={classNames(
@@ -67,7 +86,13 @@ const Card = ({
       aria-current={selected || null}
       {...rest}
     >
-      {children}
+      {(title || actions) && (
+        <div className="rc-card-header">
+          <div>{title}</div>
+          <div>{actions}</div>
+        </div>
+      )}
+      {otherChildren}
     </Element>
   );
 };

--- a/packages/react-components/source/react/library/select/SelectTarget.js
+++ b/packages/react-components/source/react/library/select/SelectTarget.js
@@ -28,11 +28,11 @@ const SelectTarget = forwardRef(
         {...rest}
       >
         <Icon
-        className="rc-input-icon trailing"
-        width="16px"
-        height="16px"
-        type="chevron-down"
-      />
+          className="rc-input-icon trailing"
+          width="16px"
+          height="16px"
+          type="chevron-down"
+        />
         {renderText(type, value, placeholder)}
       </button>
     </div>

--- a/packages/react-components/source/scss/library/components/_cards.scss
+++ b/packages/react-components/source/scss/library/components/_cards.scss
@@ -141,10 +141,9 @@ button.rc-card,
 }
 /* stylelint-enable */
 
-.rc-card-action-select {
-  position: absolute;
-  right: 17px;
-  top: 17px;
+.rc-card-header {
+  display: flex;
+  justify-content: space-between;
 }
 
 .rc-card-title:not(:last-child) {


### PR DESCRIPTION
This fixes a potential overlap of a long title with actions.

PDS-365 #resolve

Before:

![Screen Shot 2019-11-06 at 8 18 34 AM](https://user-images.githubusercontent.com/175123/68316590-8ec68980-006e-11ea-94e7-54dfb2ae4af8.png)

After:

![Screen Shot 2019-11-06 at 8 18 49 AM](https://user-images.githubusercontent.com/175123/68316606-95550100-006e-11ea-8ab9-61ce79f906cd.png)
