### PR TITLE
Add Card.Header component

### DIFF
--- a/packages/react-components/source/react/library/card/Card.js
+++ b/packages/react-components/source/react/library/card/Card.js
@@ -1,10 +1,11 @@
-import React, { Children } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { elementElevation } from '../../helpers/customPropTypes';
 
 import CardActionSelect from './CardActionSelect';
 import CardAction from './CardAction';
+import CardHeader from './CardHeader';
 import CardTitle from './CardTitle';
 
 const propTypes = {
@@ -52,27 +53,6 @@ const Card = ({
 }) => {
   const Element = assignDefaultElement(as, selectable);
 
-  // Find title and actions for placement in header
-  const childrenArray = Children.toArray(children);
-  const title = childrenArray.find(
-    child => child.type && child.type.name === 'CardTitle',
-  );
-  const actions = childrenArray.find(
-    child =>
-      child.type &&
-      (child.type.name === 'CardAction' ||
-        child.type.name === 'CardActionSelect'),
-  );
-  const otherChildren = childrenArray.filter(
-    child =>
-      !(
-        child.type &&
-        (child.type.name === 'CardTitle' ||
-          child.type.name === 'CardAction' ||
-          child.type.name === 'CardActionSelect')
-      ),
-  );
-
   return (
     <Element
       className={classNames(
@@ -88,13 +68,7 @@ const Card = ({
       aria-current={selected || null}
       {...rest}
     >
-      {(title || actions) && (
-        <div className="rc-card-header">
-          <div>{title}</div>
-          <div>{actions}</div>
-        </div>
-      )}
-      {otherChildren}
+      {children}
     </Element>
   );
 };
@@ -104,6 +78,7 @@ Card.defaultProps = defaultProps;
 
 Card.ActionSelect = CardActionSelect;
 Card.Action = CardAction;
+Card.Header = CardHeader;
 Card.Title = CardTitle;
 
 export default Card;

--- a/packages/react-components/source/react/library/card/Card.md
+++ b/packages/react-components/source/react/library/card/Card.md
@@ -111,7 +111,7 @@ const cardExampleStyle = {
 
 ### Card Content
 
-Card content is arbitrary as determined by the needs of the application. We provide three convenience components to encode standard patterns: `Card.Title`, which provides a consistently applied card header, `Card.ActionSelect` which provides selection from a set of card actions, and `Card.Action` which provides access to a single card action, pre-styled in a consistent manner.
+Card content is arbitrary as determined by the needs of the application. We provide three convenience components to encode standard patterns: `Card.Title`, which provides a consistently applied card header, `Card.ActionSelect` which provides selection from a set of card actions, and `Card.Action` which provides access to a single card action, pre-styled in a consistent manner. Title and actions should be nested inside a `Card.Header` if they are both present.
 
 #### Card with action select
 
@@ -135,8 +135,10 @@ const cardActions = [
 ];
 
 <Card>
-  <Card.Title>Title</Card.Title>
-  <Card.ActionSelect actions={cardActions} />
+  <Card.Header>
+    <Card.Title>Title</Card.Title>
+    <Card.ActionSelect actions={cardActions} />
+  </Card.Header>
   Lörem ïpsum dölor sït ämet, cönsectetur ädipiscing ëlit, sëd dö ëiusmod tëmpor
   ïncididunt üt läbore ët dölore mägna äliqua. Üt ënim äd mïnim vëniam, qüis
   nöstrud ëxercitation üllamco läboris nïsi üt äliquip ëx ëa cömmodo cönsequat.
@@ -150,8 +152,10 @@ const cardActions = [
 
 ```jsx
 <Card>
-  <Card.Title>Title</Card.Title>
-  <Card.Action onClick={() => console.log('Edit card')} />
+  <Card.Header>
+    <Card.Title>Title</Card.Title>
+    <Card.Action icon="pencil" onClick={() => console.log('Edit card')} />
+  </Card.Header>
   Lörem ïpsum dölor sït ämet, cönsectetur ädipiscing ëlit, sëd dö ëiusmod tëmpor
   ïncididunt üt läbore ët dölore mägna äliqua. Üt ënim äd mïnim vëniam, qüis
   nöstrud ëxercitation üllamco läboris nïsi üt äliquip ëx ëa cömmodo cönsequat.

--- a/packages/react-components/source/react/library/card/CardHeader.js
+++ b/packages/react-components/source/react/library/card/CardHeader.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+const propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+const defaultProps = {
+  className: '',
+  children: null,
+};
+
+/**
+ * The card header is a flex container that allows for non-overlapping title and
+ * actions.
+ */
+const CardHeader = ({ className, children, ...rest }) => (
+  <div className={classNames('rc-card-header', className)} {...rest}>
+    {children}
+  </div>
+);
+
+CardHeader.propTypes = propTypes;
+CardHeader.defaultProps = defaultProps;
+
+export default CardHeader;

--- a/packages/react-components/source/scss/library/components/_cards.scss
+++ b/packages/react-components/source/scss/library/components/_cards.scss
@@ -141,11 +141,30 @@ button.rc-card,
 }
 /* stylelint-enable */
 
-.rc-card-header {
-  display: flex;
-  justify-content: space-between;
+.rc-card-action-select {
+  position: absolute;
+  right: 17px;
+  top: 17px;
 }
 
-.rc-card-title:not(:last-child) {
+.rc-card-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+
+  .rc-card-action-select {
+    position: static;
+  }
+
+  > * {
+    flex-grow: 0;
+  }
+
+  .rc-card-title {
+    flex-grow: 1;
+  }
+}
+
+.rc-card-title {
   margin-bottom: $puppet-common-spacing-base * 4;
 }


### PR DESCRIPTION
Due to my original solution (#164) of child filtering not working with nesting (as Nebula was doing inside a Fragment), this opts instead for fixing the issue of overlapping title and actions by adding a `Card.Header` component, which acts as a flex container. Consumers can still use Card without Card.Header, but the documentation now recommends it when a Card contains both a title and actions.