### PR TITLE
Fix spacing issues with inner-focus icon buttons

### DIFF
--- a/packages/react-components/source/react/library/action-select/ActionSelect.js
+++ b/packages/react-components/source/react/library/action-select/ActionSelect.js
@@ -39,6 +39,8 @@ const propTypes = {
     'transparent',
     'text',
   ]),
+  /** If true, a focused button will use an inner instead of outer outline */
+  innerFocus: PropTypes.bool,
   /** Additional property used for connotative variants (such as danger) to choose between a strong and soft version */
   weight: PropTypes.oneOf(['bold', 'subtle']),
   /** Anchor orientation of the dropdown menu */
@@ -59,6 +61,7 @@ const defaultProps = {
   actions: [],
   label: '',
   type: 'primary',
+  innerFocus: false,
   weight: 'bold',
   anchor: 'bottom left',
   icon: null,
@@ -137,6 +140,7 @@ class ActionSelect extends Component {
       id,
       label,
       type,
+      innerFocus,
       icon,
       disabled,
       loading,
@@ -164,6 +168,7 @@ class ActionSelect extends Component {
       >
         <Button
           type={type}
+          innerFocus={innerFocus}
           weight={weight}
           icon={icon}
           trailingIcon={icon ? null : 'chevron-down'}

--- a/packages/react-components/source/react/library/button-select/ButtonSelect.js
+++ b/packages/react-components/source/react/library/button-select/ButtonSelect.js
@@ -50,6 +50,8 @@ const propTypes = {
     'transparent',
     'text',
   ]),
+  /** If true, a focused button will use an inner instead of outer outline */
+  innerFocus: PropTypes.bool,
   /** Text to render as the action label in multiple mode */
   actionLabel: PropTypes.string, //eslint-disable-line
   /** Additional property used for connotative variants (such as danger) to choose between a strong and soft version */
@@ -76,6 +78,7 @@ const defaultProps = {
   onChange() {},
   placeholder: 'Select',
   type: 'primary',
+  innerFocus: false,
   actionLabel: undefined,
   weight: 'bold',
   anchor: 'bottom left',
@@ -217,6 +220,7 @@ class ButtonSelect extends Component {
       id,
       multiple,
       type,
+      innerFocus,
       icon,
       disabled,
       loading,
@@ -254,6 +258,7 @@ class ButtonSelect extends Component {
           aria-controls={`${id}-menu`}
           aria-expanded={open}
           onClick={onClickButton}
+          innerFocus={innerFocus}
           ref={button => {
             this.button = button;
           }}

--- a/packages/react-components/source/scss/library/components/_button.scss
+++ b/packages/react-components/source/scss/library/components/_button.scss
@@ -173,6 +173,10 @@ $puppet-button-padding-vertical: 5px;
   text-decoration: none;
   vertical-align: top;
 
+  &:focus {
+    box-shadow: $puppet-common-focus-outline;
+  }
+
   .rc-button-content {
     font-family: inherit;
     font-size: inherit;
@@ -186,17 +190,6 @@ $puppet-button-padding-vertical: 5px;
     margin: auto;
     position: absolute;
     top: 0;
-  }
-
-  &:not(.rc-button-inner-focus):focus {
-    box-shadow: $puppet-common-focus-outline;
-  }
-
-  &.rc-button-inner-focus:focus {
-    border: 0;
-    box-shadow: $puppet-common-focus-outline-inset;
-    padding: ($puppet-button-padding-vertical + 1)
-      ($puppet-button-padding-horizontal + 1);
   }
 
   &:disabled,
@@ -317,6 +310,41 @@ $puppet-button-padding-vertical: 5px;
 
   .rc-button-icon-svg {
     right: 4px;
+  }
+}
+
+.rc-button-inner-focus {
+  border-radius: 0;
+
+  &:focus {
+    border: 0;
+    box-shadow: $puppet-common-focus-outline-inset;
+  }
+}
+
+.rc-button-inner-focus:not(.rc-button-text):focus {
+  padding: ($puppet-button-padding-vertical + 1)
+    ($puppet-button-padding-horizontal + 1);
+}
+
+// Inner focus requires adjusted icon positioning due to the hidden border
+.rc-button-inner-focus:not(.rc-button-text).rc-button-icon:focus {
+  &.rc-button-full {
+    padding-left: 32px;
+  }
+
+  .rc-button-icon-svg {
+    left: 8px;
+  }
+}
+
+.rc-button-trailing-icon:not(.rc-button-text).rc-button-trailing-icon:focus {
+  &.rc-button-full {
+    padding-right: 32px;
+  }
+
+  .rc-button-icon-svg {
+    right: 8px;
   }
 }
 


### PR DESCRIPTION
When rendered with an inner focus outline, the overridden padding was causing spacing issues with our icon buttons. This fixes that and also gives inner-focused buttons 0 corner radius as was intended