### PR TITLE
Update CODEOWNERS file to use GitHub team instead of usernames

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @puppetlabs/design-system-maintainers
+* @puppetlabs/design-system-codeowners


### PR DESCRIPTION
Per https://confluence.puppetlabs.com/display/OSP/Decision+rationale+for+use+of+CODEOWNERS+files this will allow us to update team membership on GitHub without requiring updating this file again.

> CODEOWNERS files will focus on GitHub team names, not individuals (although individual entries may makes the most sense in a some cases). This allows the file to remain accurate after team membership changes in the GitHub UI, and lets teams plan for all types of work their members do. It's true that names may change, but at a lesser frequency than the names of their members.