### PR TITLE
[Card] Fix Card header filtering in production builds (PDS-419)

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.11.0...HEAD)
 
 - [Select] Allow truthy string in addition to boolean `open` prop in `Select` component by [@vine77](https://github.com/vine77)
+- [Card] Fix filtering of Card title and actions in production builds by [@vine77](https://github.com/vine77)
 - [Docs] Update ButtonSelect documentation by [@vine77](https://github.com/vine77)
 
 # [5.11.0](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.10.0...@puppet/react-components@5.11.0) (2019-12-13)

--- a/packages/react-components/source/react/helpers/filterDescendants.js
+++ b/packages/react-components/source/react/helpers/filterDescendants.js
@@ -1,31 +1,27 @@
 import { Children, cloneElement } from 'react';
 
 /**
- * Given `children` and `filter` (a function that is passed `child.type.name`),
- * return the plucked descendants (even if they were nested) as a flat array
- * that match the filter criteria as well as the other descendants (in the
- * original nested structure) minus the plucked descendants.
+ * Given `children` (and their nested descendants) and `components`, return the
+ * plucked descendants that are instances of any of the given `components` as
+ * well as the other descendants in the original nested structure (minus plucked
+ * descendants).
  *
- * @param {{children: array, filter: function}} parameters
- * @returns {{pluckedDescendants: array, otherDescendants: array}} descendants
+ * @param {{children: Array|ReactNode, components: ReactElement|ReactElement[]}} parameters
+ * @returns {{pluckedDescendants: Array, otherDescendants: Array}} descendants
  */
-const filterDescendants = ({ children, filter }) => {
+const filterDescendants = ({ children, components: component }) => {
   let pluckedDescendants = [];
   const otherDescendants = [];
-
-  if (!filter) return children;
+  const components = Array.isArray(component) ? component : [component];
 
   Children.toArray(children).forEach(child => {
-    if (filter(child.type && child.type.name)) {
+    if (child.type && components.some(type => child.type === type)) {
       pluckedDescendants.push(child);
     } else if (child.props && child.props.children) {
       const {
         pluckedDescendants: nestedPluckedDescendants,
         otherDescendants: nestedOtherDescendants,
-      } = filterDescendants({
-        children: child.props.children,
-        filter,
-      });
+      } = filterDescendants({ children: child.props.children, components });
 
       if (nestedPluckedDescendants.length > 0) {
         pluckedDescendants = pluckedDescendants.concat(

--- a/packages/react-components/source/react/library/card/Card.js
+++ b/packages/react-components/source/react/library/card/Card.js
@@ -55,14 +55,10 @@ const Card = ({
   const {
     pluckedDescendants: title,
     otherDescendants: filteredDescendants,
-  } = filterDescendants({
-    children,
-    filter: childTypeName => childTypeName === 'CardTitle',
-  });
+  } = filterDescendants({ children, components: CardTitle });
   const { pluckedDescendants: actions, otherDescendants } = filterDescendants({
     children: filteredDescendants,
-    filter: childTypeName =>
-      childTypeName === 'CardAction' || childTypeName === 'CardActionSelect',
+    components: [CardAction, CardActionSelect],
   });
   const hasTitle = title.length > 0;
   const hasActions = actions.length > 0;


### PR DESCRIPTION
Ticket: https://tickets.puppetlabs.com/browse/PDS-419

The bug could cause `Card.Title` and `Card.Action` (or `Card.ActionSelect`) to be rendered on separate lines instead of the same header line. This fix updates component filtering with `filterDescendants` to match against components (a ReactComponent) instead of component names (a string), which may not be valid after minification in a production build.