### PR TITLE
Add $puppet-common-font-path variable to sass-variables

### DIFF
--- a/packages/sass-variables/_common.scss
+++ b/packages/sass-variables/_common.scss
@@ -3,6 +3,8 @@
 // still need to be consistent with our overall patterns. This variable set should be
 // added to over time but kept minimal to reduce maitainence bloat
 
+$puppet-common-font-path: './fonts' !default;
+
 // Most elements share a common border radius
 $puppet-common-border-radius: 4px !default;
 

--- a/packages/sass-variables/_fonts.scss
+++ b/packages/sass-variables/_fonts.scss
@@ -2,7 +2,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('./fonts/OpenSans-Regular.woff2') format('woff2');
+  src: url("#{$puppet-common-font-path}/OpenSans-Regular.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -11,7 +11,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 400;
-  src: url('./fonts/OpenSans-RegularItalic.woff2') format('woff2');
+  src: url("#{$puppet-common-font-path}/OpenSans-RegularItalic.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -20,7 +20,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 600;
-  src: url('./fonts/OpenSans-Semibold.woff2') format('woff2');
+  src: url("#{$puppet-common-font-path}/OpenSans-Semibold.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -29,7 +29,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 600;
-  src: url('./fonts/OpenSans-SemiboldItalic.woff2') format('woff2');
+  src: url("#{$puppet-common-font-path}/OpenSans-SemiboldItalic.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -38,7 +38,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 700;
-  src: url('./fonts/OpenSans-Bold.woff2') format('woff2');
+  src: url("#{$puppet-common-font-path}/OpenSans-Bold.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -47,7 +47,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 700;
-  src: url('./fonts/OpenSans-BoldItalic.woff2') format('woff2');
+  src: url("#{$puppet-common-font-path}/OpenSans-BoldItalic.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -56,29 +56,29 @@
   font-family: Calibre;
   font-style: normal;
   font-weight: 600;
-  src: url('./fonts/CalibreWeb-Semibold.woff2') format('woff2'),
-    url('./fonts/CalibreWeb-Semibold.woff') format('woff');
+  src: url("#{$puppet-common-font-path}/CalibreWeb-Semibold.woff2") format('woff2'),
+    url("#{$puppet-common-font-path}/CalibreWeb-Semibold.woff") format('woff');
 }
 @font-face {
   font-family: Calibre;
   font-style: italic;
   font-weight: 600;
-  src: url('./fonts/CalibreWeb-SemiboldItalic.woff2') format('woff2'),
-    url('./fonts/CalibreWeb-SemiboldItalic.woff') format('woff');
+  src: url("#{$puppet-common-font-path}/CalibreWeb-SemiboldItalic.woff2") format('woff2'),
+    url("#{$puppet-common-font-path}/CalibreWeb-SemiboldItalic.woff") format('woff');
 }
 
 @font-face {
   font-family: Inconsolata;
   font-style: normal;
   font-weight: 400;
-  src: url('./fonts/Inconsolata-Regular.woff2') format('woff2'),
-    url('./fonts/Inconsolata-Regular.woff') format('woff');
+  src: url("#{$puppet-common-font-path}/Inconsolata-Regular.woff2") format('woff2'),
+    url("#{$puppet-common-font-path}/Inconsolata-Regular.woff") format('woff');
 }
 
 @font-face {
   font-family: Inconsolata;
   font-style: normal;
   font-weight: 700;
-  src: url('./fonts/Inconsolata-Bold.woff2') format('woff2'),
-    url('./fonts/Inconsolata-Bold.woff') format('woff');
+  src: url("#{$puppet-common-font-path}/Inconsolata-Bold.woff2") format('woff2'),
+    url("#{$puppet-common-font-path}/Inconsolata-Bold.woff") format('woff');
 }

--- a/packages/sass-variables/_index.scss
+++ b/packages/sass-variables/_index.scss
@@ -1,4 +1,4 @@
-@import './fonts';
 @import './palettes';
 @import './common';
+@import './fonts';
 @import './typography';


### PR DESCRIPTION
Allows importing of react-components' `ui.scss` (and thus sass-variables) without requiring `resolve-url-loader` configured in webpack. Usage example:

#### `pds_styles.scss`
```scss
// Allow webpack to resolve font URLs relative to this entrypoint 
$puppet-common-font-path: './node_modules/@puppet/sass-variables/fonts';

@import '~@puppet/react-components/source/scss/library/ui';
```

#### `pages/index.js`
```jsx
import '../pds_styles.scss'

...
```
