### PR TITLE
Remove excess padding from Modal actions

### DIFF
--- a/packages/react-components/source/scss/library/components/_modal.scss
+++ b/packages/react-components/source/scss/library/components/_modal.scss
@@ -49,7 +49,7 @@
 }
 
 .rc-modal-actions {
-  padding: $puppet-common-spacing-base * 6;
+  padding: $puppet-common-spacing-base * 6 0 0 0;
 }
 
 .rc-modal-is-overflowing .rc-modal-actions {


### PR DESCRIPTION
From this
<img width="491" alt="Screen Shot 2020-01-23 at 1 37 14 PM" src="https://user-images.githubusercontent.com/11082532/73026027-8a944780-3de5-11ea-833c-0d307fddb58d.png">

to this
<img width="493" alt="Screen Shot 2020-01-23 at 1 37 29 PM" src="https://user-images.githubusercontent.com/11082532/73026029-8bc57480-3de5-11ea-864b-a582f321a1a7.png">
