### PR TITLE
Fix padding for modal actions

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,7 +1,8 @@
 # [Unreleased](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.13.1...HEAD)
 
-- [ActionSelect, ButtonSelect] Add `width` prop to ActionSelect and ButtonSelect (by [@rhyza](https://github.com/rhyza) in [#199](https://github.com/puppetlabs/design-system/pull/199))
-- [Breadcrumb] Fix Breadcrumb accessibility and focusability
+- [ActionSelect, ButtonSelect] Add `width` prop to ActionSelect and ButtonSelect (by [@rhyza](https://github.com/rhyza) in [#201](https://github.com/puppetlabs/design-system/pull/201))
+- [Breadcrumb] Fix Breadcrumb accessibility and focusability (by [@rhyza](https://github.com/rhyza) in [#199](https://github.com/puppetlabs/design-system/pull/199))
+- [Modal] Fix padding for modal actions, an issue introduced in 5.11.1 (by [@vine77](https://github.com/vine77) in [#204](https://github.com/puppetlabs/design-system/pull/204))
 
 # [5.13.1](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.13.0...@puppet/react-components@5.13.1) (2020-01-22)
 

--- a/packages/react-components/source/react/library/modal/Modal.js
+++ b/packages/react-components/source/react/library/modal/Modal.js
@@ -60,9 +60,10 @@ class Modal extends Component {
     const { pluckedDescendants: actions, otherDescendants } = filterDescendants(
       {
         children,
-        filter: childTypeName => childTypeName === 'ModalActions',
+        components: ModalActions,
       },
     );
+
     const hasActions = actions.length > 0;
 
     return (


### PR DESCRIPTION
I introduced this bug in #189 (released in v5.11.1). This filtering fix corrects the nesting of Modal.Actions, which fixes its padding. Thanks to @rhyza for originally looking into the issue in #203.

<img width="744" alt="Screen Shot 2020-01-23 at 2 25 23 PM" src="https://user-images.githubusercontent.com/175123/73029347-380a5980-3dec-11ea-851b-00a3191bc666.png">
