### PR TITLE
Exclude multikey shortcuts from tab keyboard navigation

### DIFF
--- a/packages/react-components/source/react/constants.js
+++ b/packages/react-components/source/react/constants.js
@@ -14,17 +14,6 @@ export const SPACE_KEY_CODE = 32;
 
 export const SIDEBAR_SUBSECTION_TRUNC_LENGTH = 6;
 
-export const isKeyModified = event => {
-  return (
-    event.getModifierState('Shift') ||
-    event.getModifierState('Fn') ||
-    event.getModifierState('Control') ||
-    event.getModifierState('Alt') ||
-    event.getModifierState('Meta') ||
-    event.getModifierState('OS')
-  );
-};
-
 export const filterOperators = [
   { symbol: '=', label: 'Equals', sentence: 'is equal to' },
   { symbol: '!=', label: "Doesn't equal", sentence: 'does not equal' },

--- a/packages/react-components/source/react/helpers/statics.js
+++ b/packages/react-components/source/react/helpers/statics.js
@@ -205,6 +205,17 @@ const cancelEvent = e => {
   }
 };
 
+export const isKeyModified = event => {
+  return (
+    event.getModifierState('Shift') ||
+    event.getModifierState('Fn') ||
+    event.getModifierState('Control') ||
+    event.getModifierState('Alt') ||
+    event.getModifierState('Meta') ||
+    event.getModifierState('OS')
+  );
+};
+
 export {
   unbindParentScroll,
   bindParentScroll,

--- a/packages/react-components/source/react/library/tabs/Tabs.js
+++ b/packages/react-components/source/react/library/tabs/Tabs.js
@@ -1,14 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import {
-  LEFT_KEY_CODE,
-  RIGHT_KEY_CODE,
-  UP_KEY_CODE,
-  isKeyModified,
-} from '../../constants';
+import { LEFT_KEY_CODE, RIGHT_KEY_CODE, UP_KEY_CODE } from '../../constants';
 import withId from '../../helpers/withId';
-import { componentHasType, focus } from '../../helpers/statics';
+import { componentHasType, focus, isKeyModified } from '../../helpers/statics';
 
 import Tab from './Tab';
 import Panel from './Panel';


### PR DESCRIPTION
Resolve [PDS-361](https://tickets.puppetlabs.com/browse/PDS-361)

Keyboard tab navigation using arrows wouldn't allow for "back" keyboard navigation (⌘-← on Mac).
PR detects when common modifier keys are pressed (Shift, Control, Command, etc) and only allows tab navigation if those keys aren't pressed.