### PR TITLE
(PDS-223) Give relevant Alerts component "alert" role

### DIFF
--- a/packages/react-components/source/react/library/alert/Alert.js
+++ b/packages/react-components/source/react/library/alert/Alert.js
@@ -68,13 +68,16 @@ class Alert extends React.Component {
     );
     let closeButton;
     let typeIcon;
+    let eventBased;
 
     switch (type) {
       case 'danger':
         typeIcon = 'alert';
+        eventBased = true;
         break;
       case 'success':
         typeIcon = 'check-circle';
+        eventBased = true;
         break;
       case 'info':
       case 'warning':
@@ -96,7 +99,12 @@ class Alert extends React.Component {
     }
 
     return (
-      <div className={classNames} {...rest}>
+      <div
+        className={classNames}
+        role={eventBased ? 'alert' : null}
+        aria-live={eventBased ? 'polite' : null}
+        {...rest}
+      >
         <Icon className="rc-alert-primary-icon" type={typeIcon} size="medium" />
         <Text className="rc-alert-message" size="small">
           {children}

--- a/packages/react-components/source/react/library/alert/Alert.md
+++ b/packages/react-components/source/react/library/alert/Alert.md
@@ -37,13 +37,13 @@ There are four types of alerts. "info" and "warning" are often persistent messag
 Add an "x" button with the `closeable` and `onClose` props.
 
 ```jsx
-<Alert
-  type="info"
-  closeable
-  onClose={() => console.log('theoretically at least')}
->
-  Did you know this alert can be dismissed?
-</Alert>
+const [open, setOpen] = React.useState(true);
+
+open && (
+  <Alert type="info" closeable onClose={() => setOpen(false)}>
+    Did you know this alert can be dismissed?
+  </Alert>
+);
 ```
 
 ### Elevation
@@ -139,19 +139,19 @@ class CustomError extends Error {
 Errors of any valid type will be displayed automatically:
 
 ```jsx
-
 const extendedError = {
-  message: 'There\'s no reason to become alarmed',
+  message: "There's no reason to become alarmed",
   causes: [
     {
-      message: 'and we hope you\'ll enjoy the rest of your flight.',
+      message: "and we hope you'll enjoy the rest of your flight.",
       causes: [
         {
-          message: 'By the way, is there anyone on board who knows how to fly a plane?'
-        }
-      ]
+          message:
+            'By the way, is there anyone on board who knows how to fly a plane?',
+        },
+      ],
     },
-  ]
+  ],
 };
 
 <div>
@@ -162,9 +162,13 @@ const extendedError = {
     <Alert.Error error="The autopilot is deflating!" />
   </Alert>
   <Alert type="info" style={{ marginBottom: 5 }}>
-    <Alert.Error error={new Error('Looks like I picked the wrong week to quit sniffing glue.')} />
+    <Alert.Error
+      error={
+        new Error('Looks like I picked the wrong week to quit sniffing glue.')
+      }
+    />
   </Alert>
-</div>
+</div>;
 ```
 
 #### Cause sensitivity:
@@ -172,21 +176,22 @@ const extendedError = {
 A primary usecase for this meta-component is to automatically display API-generated errors. In this scenario it is likely that some errors returned as causes will be overly technical, and therefor not fit for display to end-users. To solve for this case, the Error alert will hide `causes` with a numerical `sensitivity` index that is greater than zero:
 
 ```jsx
-
 const extendedError = {
   message: 'Yo, your stuff is whack!',
   causes: [
     {
-      message: 'This is the reason for whackness we will display to the user, but there is more!',
+      message:
+        'This is the reason for whackness we will display to the user, but there is more!',
     },
     {
-      message: 'Jargony jargon jargon this is the technical reason why it is whack',
+      message:
+        'Jargony jargon jargon this is the technical reason why it is whack',
       sensitivity: 50,
-    }
-  ]
+    },
+  ],
 };
 
 <Alert type="danger">
   <Alert.Error error={extendedError} />
-</Alert>
+</Alert>;
 ```


### PR DESCRIPTION
Resolves [PDS-223](https://tickets.puppetlabs.com/browse/PDS-223)

- Gives "Success" and "Danger" type alerts proper aria role since those aren't designed to be persistent messages rather than in response to user action. Does not touch "Info" or "Warning" type alerts.
- Makes `closeable` Alert example functional.