### PR TITLE
Fix Data-Grid Selection readme

### DIFF
--- a/packages/data-grid/src/__test__/Table.test.jsx
+++ b/packages/data-grid/src/__test__/Table.test.jsx
@@ -268,7 +268,7 @@ describe('Selection Props', () => {
       columns={columns}
       data={data}
       selectable
-      onUpdateData={rowCheckMockfunc}
+      onRowChecked={rowCheckMockfunc}
     />,
   );
 

--- a/packages/data-grid/src/__test__/__snapshots__/Table.test.jsx.snap
+++ b/packages/data-grid/src/__test__/__snapshots__/Table.test.jsx.snap
@@ -79,11 +79,10 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
   fixedColumn={false}
   headerCheckState={false}
   headerIndeterminateState={true}
-  horizontalSroll={false}
+  horizontalScroll={false}
   onHeaderChecked={[Function]}
   onRowChecked={[Function]}
   onSort={[Function]}
-  onUpdateData={[Function]}
   rowClassName={[Function]}
   selectable={false}
   sortedColumn={
@@ -124,9 +123,10 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
             },
           ]
         }
-        headerCheckState={false}
         headerIndeterminateState={true}
-        onHeaderChecked={[Function]}
+        onSelectAll={[Function]}
+        onSort={[Function]}
+        selectAllValue={false}
         selectable={false}
         sortedColumn={
           Object {
@@ -430,17 +430,12 @@ exports[`Snapshot test Check component matches previous HTML snapshot 2`] = `
   emptyStateMessage="Prompt to action or solution"
   fixed={false}
   fixedColumn={false}
-<<<<<<< HEAD
-  horizontalScroll={false}
-=======
   headerCheckState={false}
   headerIndeterminateState={true}
-  horizontalSroll={false}
+  horizontalScroll={false}
   onHeaderChecked={[Function]}
   onRowChecked={[Function]}
->>>>>>> Update Snapshots
   onSort={[Function]}
-  onUpdateData={[Function]}
   rowClassName={[Function]}
   selectable={false}
   sortedColumn={
@@ -481,15 +476,10 @@ exports[`Snapshot test Check component matches previous HTML snapshot 2`] = `
             },
           ]
         }
-<<<<<<< HEAD
+        headerIndeterminateState={true}
         onSelectAll={[Function]}
         onSort={[Function]}
-        selectAllValue={true}
-=======
-        headerCheckState={false}
-        headerIndeterminateState={true}
-        onHeaderChecked={[Function]}
->>>>>>> Update Snapshots
+        selectAllValue={false}
         selectable={false}
         sortedColumn={
           Object {

--- a/packages/data-grid/src/__test__/__snapshots__/Table.test.jsx.snap
+++ b/packages/data-grid/src/__test__/__snapshots__/Table.test.jsx.snap
@@ -77,7 +77,11 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
   emptyStateMessage="Prompt to action or solution"
   fixed={false}
   fixedColumn={false}
-  horizontalScroll={false}
+  headerCheckState={false}
+  headerIndeterminateState={true}
+  horizontalSroll={false}
+  onHeaderChecked={[Function]}
+  onRowChecked={[Function]}
   onSort={[Function]}
   onUpdateData={[Function]}
   rowClassName={[Function]}
@@ -120,9 +124,9 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
             },
           ]
         }
-        onSelectAll={[Function]}
-        onSort={[Function]}
-        selectAllValue={false}
+        headerCheckState={false}
+        headerIndeterminateState={true}
+        onHeaderChecked={[Function]}
         selectable={false}
         sortedColumn={
           Object {
@@ -426,7 +430,15 @@ exports[`Snapshot test Check component matches previous HTML snapshot 2`] = `
   emptyStateMessage="Prompt to action or solution"
   fixed={false}
   fixedColumn={false}
+<<<<<<< HEAD
   horizontalScroll={false}
+=======
+  headerCheckState={false}
+  headerIndeterminateState={true}
+  horizontalSroll={false}
+  onHeaderChecked={[Function]}
+  onRowChecked={[Function]}
+>>>>>>> Update Snapshots
   onSort={[Function]}
   onUpdateData={[Function]}
   rowClassName={[Function]}
@@ -469,9 +481,15 @@ exports[`Snapshot test Check component matches previous HTML snapshot 2`] = `
             },
           ]
         }
+<<<<<<< HEAD
         onSelectAll={[Function]}
         onSort={[Function]}
         selectAllValue={true}
+=======
+        headerCheckState={false}
+        headerIndeterminateState={true}
+        onHeaderChecked={[Function]}
+>>>>>>> Update Snapshots
         selectable={false}
         sortedColumn={
           Object {

--- a/packages/data-grid/src/table/ColumnHeader.jsx
+++ b/packages/data-grid/src/table/ColumnHeader.jsx
@@ -37,6 +37,8 @@ const propTypes = {
   onSelectAll: func,
   /** Allows the state of the checkbox to be defined  */
   selectAllValue: bool,
+  /** Allows users to show an dash instead of a tick  */
+  headerIndeterminateState: bool,
 };
 
 const defaultProps = {
@@ -45,6 +47,7 @@ const defaultProps = {
   selectable: false,
   onSelectAll: () => {},
   selectAllValue: false,
+  headerIndeterminateState: false,
 };
 
 const SORT_DIRECTION = { ASC: 'asc', DESC: 'desc' };
@@ -74,6 +77,7 @@ class ColumnHeader extends Component {
       selectable,
       onSelectAll,
       selectAllValue,
+      headerIndeterminateState,
     } = this.props;
     const { direction, sortDataKey } = sortedColumn;
 
@@ -93,6 +97,7 @@ class ColumnHeader extends Component {
                 label=""
                 name=""
                 className="dg-table-header-checkbox"
+                indeterminate={headerIndeterminateState}
               />
             </th>
           ) : null}

--- a/packages/data-grid/src/table/README.md
+++ b/packages/data-grid/src/table/README.md
@@ -631,7 +631,6 @@ const columns = [
 ];
 
 class StatefulParent extends React.Component {
-
   constructor() {
     super();
     this.state = {
@@ -644,7 +643,6 @@ class StatefulParent extends React.Component {
   }
 
   checkIfIndeterminateState(state) {
-    console.log('check state')
     const { data, IndeterminateState, checkAll } = this.state;
     let x = data.filter(e => e.selected === true);
 
@@ -680,7 +678,6 @@ class StatefulParent extends React.Component {
 
     // find the index of object from array that you want to update
     const objIndex = stateData.findIndex(obj => obj.unique === row.unique);
-    console.log('row selected: ', objIndex, row)
 
     // make new object of updated object.
     const updatedObj = { ...stateData[objIndex], selected: checked };
@@ -707,8 +704,6 @@ class StatefulParent extends React.Component {
 
     this.checkIfIndeterminateState();
 
-    console.log(stateData, IndeterminateState)
-
     return (
       <div>
         <Table
@@ -722,11 +717,10 @@ class StatefulParent extends React.Component {
           checkIfIndeterminateState={this.checkIfIndeterminateState}
         />
       </div>
-        );
-      }
-    };
-    <StatefulParent />;
-    
+    );
+  }
+}
+<StatefulParent />;
 ```
 
 ### Pagination table

--- a/packages/data-grid/src/table/README.md
+++ b/packages/data-grid/src/table/README.md
@@ -631,18 +631,83 @@ const columns = [
 ];
 
 class StatefulParent extends React.Component {
+
   constructor() {
     super();
-    this.state = { data };
-    this.onUpdateData = this.onUpdateData.bind(this);
+    this.state = {
+      data,
+      checkAll: false,
+      IndeterminateState: false,
+    };
+    this.onHeaderSelected = this.onHeaderSelected.bind(this);
+    this.onRowSelected = this.onRowSelected.bind(this);
   }
 
-  onUpdateData(updatedData) {
-    this.setState({ data: updatedData });
+  checkIfIndeterminateState(state) {
+    console.log('check state')
+    const { data, IndeterminateState, checkAll } = this.state;
+    let x = data.filter(e => e.selected === true);
+
+    if (x.length > 0 && IndeterminateState === false && checkAll === false) {
+      this.setState({ IndeterminateState: true });
+    } else if (
+      (x.length === 0 && IndeterminateState === true) ||
+      (x.length === 0 && checkAll === true)
+    ) {
+      this.setState({ IndeterminateState: false, checkAll: false });
+    }
+    if (x.length === data.length && checkAll === false) {
+      this.setState({ IndeterminateState: false, checkAll: true });
+    }
+  }
+
+  onHeaderSelected(checked) {
+    const { data: stateData, IndeterminateState } = this.state;
+
+    this.setState({ IndeterminateState: false, checkAll: checked });
+
+    for (let i = 0; i < stateData.length; i += 1) {
+      stateData[i].selected = checked;
+    }
+  }
+
+  onRowSelected(checked, row) {
+    const { data: stateData, checkAll } = this.state;
+
+    if (checkAll) {
+      this.setState({ checkAll: false });
+    }
+
+    // find the index of object from array that you want to update
+    const objIndex = stateData.findIndex(obj => obj.unique === row.unique);
+    console.log('row selected: ', objIndex, row)
+
+    // make new object of updated object.
+    const updatedObj = { ...stateData[objIndex], selected: checked };
+
+    // make final new array of objects by combining updated object.
+    const updatedData = [
+      ...stateData.slice(0, objIndex),
+      updatedObj,
+      ...stateData.slice(objIndex + 1),
+    ];
+
+    this.checkIfIndeterminateState(),
+      this.setState({
+        data: updatedData,
+      });
   }
 
   render() {
-    const { data: stateData } = this.state;
+    const {
+      data: stateData,
+      checkAll: headerCheckboxState,
+      IndeterminateState,
+    } = this.state;
+
+    this.checkIfIndeterminateState();
+
+    console.log(stateData, IndeterminateState)
 
     return (
       <div>
@@ -650,13 +715,18 @@ class StatefulParent extends React.Component {
           data={stateData}
           columns={columns}
           selectable
-          onUpdateData={this.onUpdateData}
+          onRowChecked={this.onRowSelected}
+          onHeaderChecked={this.onHeaderSelected}
+          headerCheckState={headerCheckboxState}
+          headerIndeterminateState={IndeterminateState}
+          checkIfIndeterminateState={this.checkIfIndeterminateState}
         />
       </div>
-    );
-  }
-}
-<StatefulParent />;
+        );
+      }
+    };
+    <StatefulParent />;
+    
 ```
 
 ### Pagination table


### PR DESCRIPTION
The selection part of the readme was not showing the users the correct implementation. This will hopefully fix that.  It also adds a prop that will allow users to control the headers indeterminate state. 
![Screen-Recording-2020-02-17-at-15 43 00](https://user-images.githubusercontent.com/30826846/74668832-ef9d4c00-519d-11ea-8e96-87c2480e574d.gif)

