### PR TITLE
PDS-446 add `confirmButtonLoading` prop to `ConfirmationModal`

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1074,3 +1074,4 @@ Fix regressions in three areas:
 
 - Add filter icon
 - Make Tab panels clickable
+- Add confirmButtonLoading prop to ConfirmationModal

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.16.0...HEAD)
 
+- [ConfirmationModal] Add `confirmButtonLoading` prop to ConfirmationModal (by [@VitaC123](https://github.com/VitaC123) in [#223](https://github.com/puppetlabs/design-system/pull/223))
+
 # [5.16.0](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.15.2...@puppet/react-components@5.16.0) (2020-02-24)
 
 - [sass-variables] Add breakpoint variables and media query mixins for use in responsive layouts (by [@caseywilliams](https://github.com/caseywilliams) in [#218](https://github.com/puppetlabs/design-system/pull/218))
@@ -1074,4 +1076,3 @@ Fix regressions in three areas:
 
 - Add filter icon
 - Make Tab panels clickable
-- Add confirmButtonLoading prop to ConfirmationModal

--- a/packages/react-components/source/react/library/confirmation-modal/ConfirmationModal.js
+++ b/packages/react-components/source/react/library/confirmation-modal/ConfirmationModal.js
@@ -22,6 +22,8 @@ const propTypes = {
   onConfirm: PropTypes.func,
   /** Function to call when action is cancelled, close button is clicked, or ESC is pressed */
   onCancel: PropTypes.func,
+  /** If true, confirm button will render with a loading spinner */
+  confirmButtonLoading: PropTypes.bool,
 };
 const defaultProps = {
   title: '',
@@ -33,6 +35,7 @@ const defaultProps = {
   cancelButtonType: 'tertiary',
   onConfirm: () => {},
   onCancel: () => {},
+  confirmButtonLoading: false,
 };
 
 const ConfirmationModal = ({
@@ -45,12 +48,17 @@ const ConfirmationModal = ({
   cancelButtonType,
   onConfirm,
   onCancel,
+  confirmButtonLoading,
 }) => (
   <Modal onClose={onCancel} isOpen={isOpen}>
     {title && <Modal.Title>{title}</Modal.Title>}
     {description}
     <Modal.Actions>
-      <Button type={confirmButtonType} onClick={onConfirm}>
+      <Button
+        type={confirmButtonType}
+        onClick={onConfirm}
+        loading={confirmButtonLoading}
+      >
         {confirmLabel}
       </Button>
       <Button type={cancelButtonType} onClick={onCancel}>


### PR DESCRIPTION
This commit adds a loading prop to to the `ConfirmationModal`'s confirm
button, to activate the button's loading state. This will be useful for
interactions where clicking the confirm button fires off an async action,
such as a a database delete operation, and we want to keep the user
in the modal until it completes.

https://tickets.puppetlabs.com/browse/PDS-446

I tested these changes manually by running the Styleguidist server.

![image](https://user-images.githubusercontent.com/17498763/75264676-9daf8400-57a4-11ea-97a5-8021810ec87e.png)
