### PR TITLE
Add height prop to Toolbar

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,8 @@
-# [Unreleased](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.19.1...HEAD)
+# [Unreleased](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.19.2...HEAD)
 
+# [5.19.2](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.19.1...@puppet/react-components@5.19.2) (2020-03-23)
+
+- [Toolbar] Add `height` prop to Toolbar (by [@vine77](https://github.com/vine77) in [#237](https://github.com/puppetlabs/design-system/pull/237))
 - [Docs] Add glossary of components by category (by [sprokusk](https://github.com/sprokusk) in [#236](https://github.com/puppetlabs/design-system/pull/236))
 
 # [5.19.1](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.19.0...@puppet/react-components@5.19.1) (2020-03-18)

--- a/packages/react-components/source/react/library/toolbar/Toolbar.js
+++ b/packages/react-components/source/react/library/toolbar/Toolbar.js
@@ -4,22 +4,29 @@ import classNames from 'classnames';
 import Actions from './Actions';
 
 const propTypes = {
+  /** Should the Toolbar have a top and bottom border */
   border: PropTypes.bool,
+  /** Children may include Tabs or Toolbar.Actions */
   children: PropTypes.node,
+  /** Additional class name */
   className: PropTypes.string,
+  /** Height in percent, e.g. "100%", or pixels */
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 const defaultProps = {
   border: false,
   children: null,
   className: '',
+  height: null,
 };
 
-const Toolbar = ({ border, children, className }) => (
+const Toolbar = ({ border, children, className, height }) => (
   <div
     className={classNames('rc-toolbar', className, {
       'rc-toolbar-border': border,
     })}
+    style={{ height }}
   >
     {children}
   </div>

--- a/packages/react-components/source/react/library/toolbar/Toolbar.md
+++ b/packages/react-components/source/react/library/toolbar/Toolbar.md
@@ -4,6 +4,8 @@ Toolbar acts as a container for tabs and buttons that is unified and compact.
 
 ## Basic use
 
+The Toolbar may be used without tabs if it only contains buttons.
+
 ```jsx
 import Button from '../button';
 
@@ -19,6 +21,9 @@ import Button from '../button';
 ```
 
 ## Toolbar with Tabs
+
+Note: If tab panels are expected to expand to full height, then Toolbar (the
+container of Tabs) may need to add `height="100%"`.
 
 ```jsx
 import Button from '../button';


### PR DESCRIPTION
This adds a `height` prop to the Toolbar component, which is needed for layouts that contain full-height tabs, and some docs.