### PR TITLE
Remove margin from Badge component

### DIFF
--- a/packages/react-components/source/scss/library/components/_badge.scss
+++ b/packages/react-components/source/scss/library/components/_badge.scss
@@ -4,7 +4,6 @@
   border-radius: 2px;
   display: inline-flex;
   justify-content: center;
-  margin: 0 $puppet-common-spacing-base * 0.5;
   min-height: $puppet-common-spacing-base * 4;
   padding: 0 $puppet-common-spacing-base;
   text-transform: uppercase;

--- a/packages/react-components/source/scss/library/components/_badge.scss
+++ b/packages/react-components/source/scss/library/components/_badge.scss
@@ -9,6 +9,10 @@
   text-transform: uppercase;
 }
 
+.rc-badge + .rc-badge {
+  margin-left: $puppet-common-spacing-base;
+}
+
 .rc-badge-pill {
   border-radius: 1000px;
   padding: 0 $puppet-common-spacing-base * 4;


### PR DESCRIPTION
The left/right outer margins for Badge are inconsistent with our other components that don't have any outer margin. We otherwise require the consumer to set margins between components. This change will require any consumers relying on this behavior to add the margins to their consuming app.

This issue was noticed by me in nebula-ui where a Badge got overly indented due to not removing these margins and by @sprokusk in relay-website who overrode this margin to 0.

The only exception to react-components specifying margins is in [_button.scss#L356-L358](https://github.com/puppetlabs/design-system/blob/8a7a4fd76ee9ffc6da1decb360fc17ac4a8ad104/packages/react-components/source/scss/library/components/_button.scss#L356-L358) but that is strictly adding margins only between multiple Buttons components.