### PR TITLE
Fix icon for info Alert

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [Unreleased](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.19.5...HEAD)
 
+- [Alert] Fix icon for info Alert, an issue introduced in 5.0.0-beta.3 (by [@vine77](https://github.com/vine77) in [#242](https://github.com/puppetlabs/design-system/pull/242))
 - [Badge] Remove outer margin from Badge component while retaining margin between adjacent Badge components (by [@vine77](https://github.com/vine77) in [#241](https://github.com/puppetlabs/design-system/pull/241))
 
 # [5.19.4](https://github.com/puppetlabs/design-system/compare/@puppet/react-components@5.19.3...@puppet/react-components@5.19.4) (2020-04-05)

--- a/packages/react-components/source/react/library/alert/Alert.js
+++ b/packages/react-components/source/react/library/alert/Alert.js
@@ -71,15 +71,13 @@ class Alert extends React.Component {
 
     switch (type) {
       case 'danger':
+      case 'warning':
         typeIcon = 'alert';
         break;
       case 'success':
         typeIcon = 'check-circle';
         break;
       case 'info':
-      case 'warning':
-        typeIcon = 'alert';
-        break;
       default:
         typeIcon = 'info-circle';
     }


### PR DESCRIPTION
Fix icon for `<Alert type="info">` to be the "i" circle info icon instead of the triangle exclamation point icon (an issue introduced in 5.0.0-beta.3).

<img width="1155" alt="Screen Shot 2020-04-15 at 9 08 12 PM" src="https://user-images.githubusercontent.com/175123/79413630-53a17e00-7f5d-11ea-9f6d-deab460a97d8.png">
