### PR TITLE
Fix #245: Loosen type checking constraints slightly.

### DIFF
--- a/packages/react-components/source/react/helpers/statics.js
+++ b/packages/react-components/source/react/helpers/statics.js
@@ -55,8 +55,13 @@ const mapObj = (obj, fn) => {
   return mappedObj;
 };
 
-const componentHasType = (component, Type) =>
-  component && component.type && component.type === Type;
+const displayNameOrName = (t) => t.displayName || t.name;
+
+const componentHasType = (component, Type) => 
+  // we use displayName here instead of just name because React might use a
+  // proxy during rendering. We care about the underlying type because that
+  // describes how the component behaves.
+  component && component.type && displayNameOrName(component.type) === displayNameOrName(Type);
 
 const omit = (keys, object) => {
   const keySet = new Set(keys);


### PR DESCRIPTION
This PR is just a proposal for how we _could_ fix bug #245. I think it's likewise acceptable to not be bothered and make a recommendation to our users that they migrate off `react-hot-loader` as it's incompatible.