### PR TITLE
Add `innerClassName` prop to Form.Field

### DIFF
--- a/packages/react-components/source/react/library/form/FormField.js
+++ b/packages/react-components/source/react/library/form/FormField.js
@@ -43,6 +43,8 @@ const propTypes = {
   onChange: PropTypes.func,
   /** Optional additional className */
   className: PropTypes.string,
+  /** Optional additional className for inner field */
+  innerClassName: PropTypes.string,
   /** Optional additional inline styles */
   style: PropTypes.shape({}),
   /** All additional props are propagated to the inner input elements. See each option for details. TODO: figure out how to get this set up in styleguidist */
@@ -62,6 +64,7 @@ const defaultProps = {
   inlineLabelWidth: null,
   onChange() {},
   className: '',
+  innerClassName: '',
   style: {},
 };
 
@@ -108,23 +111,24 @@ const getFieldStyle = (style, inlineLabelWidth, tabbed) => {
 
 const FormField = props => {
   const {
-    type,
-    name,
-    label,
-    labelType,
     className,
+    description,
+    error,
+    innerClassName,
     inline,
     inlineLabelWidth,
-    error,
-    description,
+    label,
+    labelType,
+    name,
     style,
+    type,
   } = props;
   const typeName = getTypeName(type);
   const tabbed = inline && (type === 'checkbox' || type === 'switch');
   const labelStyle = getLabelStyle(inlineLabelWidth, inline);
   const fieldStyle = getFieldStyle(style, inlineLabelWidth, tabbed);
 
-  const element = <FormFieldElement {...props} />;
+  const element = <FormFieldElement {...props} className={innerClassName} />;
 
   if (type === 'hidden') {
     return element;

--- a/packages/react-components/source/react/library/form/FormField.js
+++ b/packages/react-components/source/react/library/form/FormField.js
@@ -73,15 +73,16 @@ const defaultProps = {
  */
 export const formInputInterface = omit(
   [
-    'requiredFieldMessage',
-    'validateOnLoad',
-    'validator',
     'className',
     'description',
-    'style',
-    'labelType',
     'inline',
     'inlineLabelWidth',
+    'innerClassName',
+    'labelType',
+    'requiredFieldMessage',
+    'style',
+    'validateOnLoad',
+    'validator',
   ],
   propTypes,
 );

--- a/packages/react-components/source/react/library/form/internal/FormFieldElement.js
+++ b/packages/react-components/source/react/library/form/internal/FormFieldElement.js
@@ -51,11 +51,11 @@ const FormFieldElement = props => {
 
   const elementProps = omit(
     [
+      'description',
       'inline',
       'inlineLabelWidth',
+      'innerClassName',
       'labelType',
-      'description',
-      'className',
       'style',
       'requiredFieldMessage',
       'validateOnLoad',

--- a/packages/react-components/test/form/FormField.js
+++ b/packages/react-components/test/form/FormField.js
@@ -95,6 +95,14 @@ describe('<FormField />', () => {
     );
   });
 
+  it('applies an innerClassName to the inner input element', () => {
+    expect(
+      mount(<FormField {...requiredProps} innerClassName="hello-world" />).find(
+        Input,
+      ),
+    ).to.have.prop('className', 'hello-world');
+  });
+
   it('renders an Input for all Input supported types', () => {
     INPUT_SUPPORTED_TYPES.forEach(type => {
       expect(


### PR DESCRIPTION
The `className` gets applied to the wrapping div, so adding an `innerClassName` allows us to target the inner form field element.

Note: This is a prerequisite for [PN-1002](https://tickets.puppetlabs.com/browse/PN-1002)