### PR TITLE
Allow node type in SidePanel title prop

### DIFF
--- a/packages/react-components/source/react/library/sidepanel/SidePanel.js
+++ b/packages/react-components/source/react/library/sidepanel/SidePanel.js
@@ -12,7 +12,7 @@ const propTypes = {
   contentClassName: PropTypes.string,
   onClose: PropTypes.func,
   open: PropTypes.bool,
-  title: PropTypes.string,
+  title: PropTypes.node,
   type: PropTypes.oneOf(['toolbar']).isRequired,
   toolbarType: PropTypes.oneOf(['primary', 'secondary']),
 };


### PR DESCRIPTION
Relay gets the following warning when we try to pass a <span> including an <Icon> to SidePanel's `title` prop.

```
react_devtools_backend.js:6 Warning: Failed prop type: Invalid prop `title` of type `object` supplied to `SidePanel`, expected `string`.
```

For example:

```
<SidePanel
  type="toolbar"
  toolbarType="primary"
  title={
    <span className="workflow-detail-sidebar-heading-title">
      <Icon type="gear" />
      {t(`sidebars.${aside}.title`, { stepName, workflowName })}
    </span>
  }
>
```