### PR TITLE
Clarify internal use

### DIFF
--- a/packages/design-system-website/README.md
+++ b/packages/design-system-website/README.md
@@ -4,7 +4,7 @@
 
 The Puppet Design System (PDS) is a collection of the common values, behaviors, components, and styles we share at Puppet. It represents our shared objective to quickly deliver value to our customers. With it we scale design across departments, platforms, and time zones.
 
-For background, see [Puppet Design System](https://confluence.puppetlabs.com/display/PDS) on Confluence or watch the [Big Picture presentation](https://primetime.bluejeans.com/a2m/events/playback/33fcd61c-3ad2-4413-9393-cc216551d61b).
+This is built for internal use across the Puppet family of products, but others might find it useful as well.
 
 ### Getting started
 
@@ -20,4 +20,10 @@ The Puppet Design System is a cross-functional team effort with shared ownership
 
 ### Feedback
 
-We are continuing to iterate on the PDS, and appreciate your feedback and questions. Say hi in Slack in the [#team-design-system](https://puppet.slack.com/messages/CFFECRQAY) channel, contact [puppet-design-system@puppet.com](mailto:puppet-design-system@puppet.com) or [report an issue](https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=16902&issuetype=1&priority=6) in Jira (the “PDS” project).
+We are continuing to iterate on the PDS. The current focus is on internal use, but we always appreciate everyone's feedback and questions. Please [report issues](https://github.com/puppetlabs/design-system/issues) you find or contact [puppet-design-system@puppet.com](mailto:puppet-design-system@puppet.com).
+
+## Internal use
+
+For background on the project, see [Puppet Design System](https://confluence.puppetlabs.com/display/PDS) on Confluence or watch the [Big Picture presentation](https://primetime.bluejeans.com/a2m/events/playback/33fcd61c-3ad2-4413-9393-cc216551d61b).
+
+You can talk with the Design System team in Slack in the [#team-design-system](https://puppet.slack.com/messages/CFFECRQAY) channel, or [report an issue](https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=16902&issuetype=1&priority=6) in Jira (the “PDS” project).


### PR DESCRIPTION
Since the https://puppet.style site is on the public internet, this just clarifies the internal use of the system and groups internal links into a single section.