### PR TITLE
Add data-grid loading state

### DIFF
--- a/packages/data-grid/src/__test__/Table.test.jsx
+++ b/packages/data-grid/src/__test__/Table.test.jsx
@@ -87,7 +87,7 @@ const wrapper4 = mount(<Table columns={sortedColumns} data={data} />);
 const wrapper6 = mount(
   <Table columns={columns} data={data} rowClassName="testRowClassName" />,
 );
-const wrapper7 = mount(<Table columns={columns} data={data} isLoading />);
+const wrapper7 = mount(<Table columns={columns} data={data} loading />);
 
 describe('Snapshot test', () => {
   test('Check component matches previous HTML snapshot', () => {

--- a/packages/data-grid/src/__test__/Table.test.jsx
+++ b/packages/data-grid/src/__test__/Table.test.jsx
@@ -87,6 +87,7 @@ const wrapper4 = mount(<Table columns={sortedColumns} data={data} />);
 const wrapper6 = mount(
   <Table columns={columns} data={data} rowClassName="testRowClassName" />,
 );
+const wrapper7 = mount(<Table columns={columns} data={data} isLoading />);
 
 describe('Snapshot test', () => {
   test('Check component matches previous HTML snapshot', () => {
@@ -106,6 +107,14 @@ describe('Data Prop', () => {
       wrapper3
         .find('div.dg-empty-state-container')
         .hasClass('dg-empty-state-container'),
+    ).toEqual(true);
+  });
+
+  test('that when table is loading it renders loading state', () => {
+    expect(
+      wrapper7
+        .find('div.dg-table-loading-inner-container')
+        .hasClass('dg-table-loading-inner-container'),
     ).toEqual(true);
   });
 

--- a/packages/data-grid/src/__test__/__snapshots__/Table.test.jsx.snap
+++ b/packages/data-grid/src/__test__/__snapshots__/Table.test.jsx.snap
@@ -80,6 +80,8 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
   headerCheckState={false}
   headerIndeterminateState={true}
   horizontalScroll={false}
+  isLoading={false}
+  loadingMessage="Loading"
   onHeaderChecked={[Function]}
   onRowChecked={[Function]}
   onSort={[Function]}
@@ -124,6 +126,8 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
           ]
         }
         headerIndeterminateState={true}
+        isLoading={false}
+        loadingMessage="Loading"
         onSelectAll={[Function]}
         onSort={[Function]}
         selectAllValue={false}
@@ -433,6 +437,8 @@ exports[`Snapshot test Check component matches previous HTML snapshot 2`] = `
   headerCheckState={false}
   headerIndeterminateState={true}
   horizontalScroll={false}
+  isLoading={false}
+  loadingMessage="Loading"
   onHeaderChecked={[Function]}
   onRowChecked={[Function]}
   onSort={[Function]}
@@ -477,6 +483,8 @@ exports[`Snapshot test Check component matches previous HTML snapshot 2`] = `
           ]
         }
         headerIndeterminateState={true}
+        isLoading={false}
+        loadingMessage="Loading"
         onSelectAll={[Function]}
         onSort={[Function]}
         selectAllValue={false}

--- a/packages/data-grid/src/__test__/__snapshots__/Table.test.jsx.snap
+++ b/packages/data-grid/src/__test__/__snapshots__/Table.test.jsx.snap
@@ -80,7 +80,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
   headerCheckState={false}
   headerIndeterminateState={true}
   horizontalScroll={false}
-  isLoading={false}
+  loading={false}
   loadingMessage="Loading"
   onHeaderChecked={[Function]}
   onRowChecked={[Function]}
@@ -126,7 +126,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
           ]
         }
         headerIndeterminateState={true}
-        isLoading={false}
+        loading={false}
         loadingMessage="Loading"
         onSelectAll={[Function]}
         onSort={[Function]}
@@ -437,7 +437,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 2`] = `
   headerCheckState={false}
   headerIndeterminateState={true}
   horizontalScroll={false}
-  isLoading={false}
+  loading={false}
   loadingMessage="Loading"
   onHeaderChecked={[Function]}
   onRowChecked={[Function]}
@@ -483,7 +483,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 2`] = `
           ]
         }
         headerIndeterminateState={true}
-        isLoading={false}
+        loading={false}
         loadingMessage="Loading"
         onSelectAll={[Function]}
         onSort={[Function]}

--- a/packages/data-grid/src/table/README.md
+++ b/packages/data-grid/src/table/README.md
@@ -145,7 +145,7 @@ const emptyStateMessage = 'Reconnect to service';
 
 ### Loading State
 
-In the case where a query is in progress you may need to have the table in a loading state. You can trigger this loading state by adding a Boolean value to the isLoading prop. You can also customize the message displayed to the user by passing your own string into the loadingMessage prop by default this will be "Loading".
+In the case where a query is in progress you may need to have the table in a loading state. You can trigger this loading state by adding a Boolean value to the loading prop. You can also customize the message displayed to the user by passing your own string into the loadingMessage prop by default this will be "Loading".
 
 ```jsx
 import { Link } from '@puppet/react-components';
@@ -215,7 +215,7 @@ const columns = [
   { label: 'Linked field', dataKey: 'Link' },
 ];
 
-<Table data={data} columns={columns} isLoading={true} />;
+<Table data={data} columns={columns} loading={true} />;
 ```
 
 ### Custom Row Styling

--- a/packages/data-grid/src/table/README.md
+++ b/packages/data-grid/src/table/README.md
@@ -143,6 +143,81 @@ const emptyStateMessage = 'Reconnect to service';
 </div>;
 ```
 
+### Loading State
+
+In the case where a query is in progress you may need to have the table in a loading state. You can trigger this loading state by adding a Boolean value to the isLoading prop. You can also customize the message displayed to the user by passing your own string into the loadingMessage prop by default this will be "Loading".
+
+```jsx
+import { Link } from '@puppet/react-components';
+const data = [
+  {
+    eventType: 'Application Control',
+    affectedDevices: 0,
+    detections: 1000,
+    sorted: 'asc',
+    Link: <Link href="https://puppet.com/">Help to fix</Link>,
+    unique: 6,
+  },
+  {
+    eventType: 'Virus/Malware',
+    affectedDevices: 20,
+    detections: 634,
+    unique: 1,
+    Link: <Link href="https://puppet.com/">Help to fix</Link>,
+    selected: true,
+  },
+  {
+    eventType: 'Spyware/Grayware',
+    affectedDevices: 20,
+    detections: 634,
+    Link: <Link href="https://puppet.com/">Help to fix</Link>,
+    unique: 2,
+  },
+  {
+    eventType: 'URL Filtering',
+    affectedDevices: 16,
+    detections: 599,
+    Link: <Link href="https://puppet.com/">Help to fix</Link>,
+    unique: 3,
+  },
+  {
+    eventType: 'Web Reputation',
+    affectedDevices: 15,
+    detections: 598,
+    Link: <Link href="https://puppet.com/">Help to fix</Link>,
+    unique: 4,
+  },
+  {
+    eventType: 'Network Virus',
+    affectedDevices: 15,
+    detections: 497,
+    Link: <Link href="https://puppet.com/">Help to fix</Link>,
+    unique: 5,
+  },
+
+  {
+    eventType: 'Application Controls',
+    affectedDevices: 0,
+    detections: 0,
+    Link: <Link href="https://puppet.com/">Help to fix</Link>,
+    unique: 7,
+  },
+];
+
+const columns = [
+  {
+    label: 'Event Type1',
+    dataKey: 'eventType',
+  },
+  { label: 'Affected Devices', dataKey: 'affectedDevices' },
+
+  { label: 'Detections', dataKey: 'detections' },
+  { label: 'Linked field', dataKey: 'Link' },
+];
+
+<Table data={data} columns={columns} isLoading={true} />;
+```
+
 ### Custom Row Styling
 
 Should the need arise where you have to add styling to the table rows. The best practice is to use the 'rowClassNames' prop to assign a css classname each row. Should you need to carry out conditional styling a function can be supplied.

--- a/packages/data-grid/src/table/Table.jsx
+++ b/packages/data-grid/src/table/Table.jsx
@@ -59,7 +59,7 @@ const propTypes = {
     sortDataKey: string,
   }),
   /** Boolean to determine whether to display loading state */
-  isLoading: bool,
+  loading: bool,
   /** Optional string to provide alternative message when loading */
   loadingMessage: string,
   /** Callback function that will return direction and dataKey on every sort action  */
@@ -95,7 +95,7 @@ const defaultProps = {
   fixedColumn: false,
   emptyStateHeader: 'No data available',
   emptyStateMessage: 'Prompt to action or solution',
-  isLoading: false,
+  loading: false,
   loadingMessage: 'Loading',
   rowClassName: () => {},
   selectable: false,
@@ -142,7 +142,7 @@ class Table extends Component {
       rowKey,
       className,
       sortedColumn,
-      isLoading,
+      loading,
       loadingMessage,
       fixedColumn,
       horizontalScroll,
@@ -178,7 +178,7 @@ class Table extends Component {
           {...rest}
         >
           <ColumnHeader
-            isLoading={isLoading}
+            loading={loading}
             loadingMessage={loadingMessage}
             columns={columns}
             selectable={selectable}
@@ -189,14 +189,17 @@ class Table extends Component {
             headerIndeterminateState={headerIndeterminateState}
           />
           <tbody>
-            {isLoading && (
+            {loading && (
               <tr className="rc-table-cell">
                 <th
-                  ref={this.loadingHeaderRef}
                   className="dg-table-loading-container"
                   colSpan={columns.length}
                 >
-                  <div className="dg-table-loading-inner-container">
+                  <div
+                    className="dg-table-loading-inner-container"
+                    aria-live="polite"
+                    aria-busy={loading}
+                  >
                     <div>
                       <Loading className="dg-loading-size" />
                     </div>

--- a/packages/data-grid/src/table/Table.jsx
+++ b/packages/data-grid/src/table/Table.jsx
@@ -11,7 +11,7 @@ import {
 } from 'prop-types';
 import classNames from 'classnames';
 import { get } from 'lodash';
-import { Heading, Checkbox, Text } from '@puppet/react-components';
+import { Heading, Checkbox, Text, Loading } from '@puppet/react-components';
 
 import ColumnHeader from './ColumnHeader';
 import TableHeader from '../tableHeader/TableHeader';
@@ -58,6 +58,10 @@ const propTypes = {
     /** Descibes the column being sorted using the column dataKey  */
     sortDataKey: string,
   }),
+  /** Boolean to determine whether to display loading state */
+  isLoading: bool,
+  /** Optional string to provide alternative message when loading */
+  loadingMessage: string,
   /** Callback function that will return direction and dataKey on every sort action  */
   onSort: func,
   /** Optional boolean to cause horizontal scrolling when table extends past the container */
@@ -91,6 +95,8 @@ const defaultProps = {
   fixedColumn: false,
   emptyStateHeader: 'No data available',
   emptyStateMessage: 'Prompt to action or solution',
+  isLoading: false,
+  loadingMessage: 'Loading',
   rowClassName: () => {},
   selectable: false,
   onRowChecked: () => {},
@@ -136,6 +142,8 @@ class Table extends Component {
       rowKey,
       className,
       sortedColumn,
+      isLoading,
+      loadingMessage,
       fixedColumn,
       horizontalScroll,
       emptyStateHeader,
@@ -170,6 +178,8 @@ class Table extends Component {
           {...rest}
         >
           <ColumnHeader
+            isLoading={isLoading}
+            loadingMessage={loadingMessage}
             columns={columns}
             selectable={selectable}
             sortedColumn={sortedColumn}
@@ -179,6 +189,28 @@ class Table extends Component {
             headerIndeterminateState={headerIndeterminateState}
           />
           <tbody>
+            {isLoading && (
+              <tr className="rc-table-cell">
+                <th
+                  ref={this.loadingHeaderRef}
+                  className="dg-table-loading-container"
+                  colSpan={columns.length}
+                >
+                  <div className="dg-table-loading-inner-container">
+                    <div>
+                      <Loading className="dg-loading-size" />
+                    </div>
+                    <Heading
+                      as="h5"
+                      color="medium"
+                      className="dg-table-loading-header"
+                    >
+                      {loadingMessage}
+                    </Heading>
+                  </div>
+                </th>
+              </tr>
+            )}
             {data.map((rowData, rowIndex) => {
               return (
                 <tr
@@ -222,7 +254,6 @@ class Table extends Component {
                       ...defaultColumnDefs,
                       ...column,
                     };
-
                     return (
                       <td
                         key={`${(rowIndex, dataKey)}`}

--- a/packages/data-grid/src/table/Table.scss
+++ b/packages/data-grid/src/table/Table.scss
@@ -104,3 +104,29 @@
     background-color: $puppet-n200;
   }
 }
+
+/** Loading State **/
+
+.dg-table-loading-container {
+  width: 100%;
+  padding: 5px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: $puppet-white;
+
+  .dg-table-loading-inner-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .dg-loading-size {
+    height: 30px;
+    width: 30px;
+  }
+
+  .dg-table-loading-header {
+    margin-left: 10px;
+  }
+}


### PR DESCRIPTION
This PR is for the addition of a Loading State to the current Data-grid package. For loading state designs see [here](https://www.figma.com/file/UsyWi3PNN2DhfZa9nqSDjd/UX-bits?node-id=942%3A0).

This includes the addition of two new props to the data-grid:

**loading** : Boolean to determine whether to display loading state - defaulted to false
**loadingMessage** : Optional string to provide alternative message when loading - default will be "Loading".

**Loading State on Table**
![Screenshot 2020-07-30 at 16 12 05](https://user-images.githubusercontent.com/20307965/88941049-73488200-d280-11ea-8ff5-db7fde915f1c.png)

**Loading Header on Scroll**
![Screenshot 2020-07-30 at 16 12 55](https://user-images.githubusercontent.com/20307965/88941059-75124580-d280-11ea-9e65-6ae55f7da68e.png)

**NB: Due to our design system app having a padding of 40px applied to the main-app this causes the loading state position on scroll to have additional padding on-top. This behaves fine once the padding has been removed through the chrome html tools. In the screenshot above I've taken this padding off to show how the data-grid loading state would behave.**