### PR TITLE
Don't require Element prop-type in Tooltip

### DIFF
--- a/packages/react-components/source/react/library/tooltips/Tooltip.js
+++ b/packages/react-components/source/react/library/tooltips/Tooltip.js
@@ -7,7 +7,10 @@ const TOOLTIP_OFFSET = 6;
 
 const propTypes = {
   anchor: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
-  target: PropTypes.instanceOf(Element).isRequired,
+  target: (typeof Element === 'undefined'
+    ? PropTypes.any
+    : PropTypes.instanceOf(Element)
+  ).isRequired,
   children: PropTypes.node,
   className: PropTypes.string,
   style: PropTypes.shape({}),


### PR DESCRIPTION
Fixes #284 - Referencing `Element` can cause errors in SSR contexts -
this lets `Tooltip`'s `target` prop fall back to `PropTypes.any` when
`Element` is undefined.