### PR TITLE
(PDS-502) Add 'transparent' Tabs variant, make Tabs scrollable at narrow widths

### DIFF
--- a/packages/react-components/source/react/library/tabs/Tabs.js
+++ b/packages/react-components/source/react/library/tabs/Tabs.js
@@ -1,12 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { LEFT_KEY_CODE, RIGHT_KEY_CODE, UP_KEY_CODE } from '../../constants';
+import {
+  ENTER_KEY_CODE,
+  LEFT_KEY_CODE,
+  RIGHT_KEY_CODE,
+  UP_KEY_CODE,
+} from '../../constants';
 import withId from '../../helpers/withId';
 import { componentHasType, focus, isKeyModified } from '../../helpers/statics';
 
 import Tab from './Tab';
 import Panel from './Panel';
+import Button from '../button';
+
+const SCROLL_BUTTON_WIDTH = 32;
 
 const propTypes = {
   /** Nested Tab.Tabs components */
@@ -24,6 +32,8 @@ const propTypes = {
   onChange: PropTypes.func,
   /** Add padding to tab pane */
   panePadding: PropTypes.bool,
+  /** Whether to respond to a smaller container width by enabling horizontal scrolling and showing left/right buttons */
+  scroll: PropTypes.bool,
   /** Optional additional inline style */
   style: PropTypes.shape({}),
   /** Whether to use the transparent tab design instead of the default outlined tabs */
@@ -38,6 +48,7 @@ const defaultProps = {
   initialTab: null,
   onChange() {},
   panePadding: true,
+  scroll: true,
   style: {},
   transparent: false,
   type: 'primary',
@@ -71,25 +82,64 @@ const getActiveTab = (props, state) => {
   const activeIndex = tabsProps.findIndex(p => p.id === activeTab);
 
   return {
+    ...state,
     activeTab,
     activeIndex,
   };
+};
+
+// Scrolls the `tabNode` into view within the `listNode`
+const revealTab = (listNode, tabNode, marginOffset = 0) => {
+  const visibleWidth = listNode.offsetWidth;
+  const tabWidth = tabNode.offsetWidth;
+  const tabLeft = tabNode.offsetLeft;
+  const tabRight = tabLeft + tabWidth;
+  const visibleAreaLeft = listNode.scrollLeft;
+  const visibleAreaRight = visibleAreaLeft + visibleWidth;
+
+  let scrollAmount = marginOffset;
+
+  if (visibleAreaRight < tabRight) {
+    scrollAmount += tabRight - visibleAreaRight;
+    if (listNode.scrollLeft === 0) {
+      scrollAmount += SCROLL_BUTTON_WIDTH;
+    }
+    // eslint-disable-next-line
+    listNode.scrollLeft += scrollAmount;
+  } else if (visibleAreaLeft > tabLeft) {
+    scrollAmount += visibleAreaLeft - tabLeft;
+    // eslint-disable-next-line
+    listNode.scrollLeft -= scrollAmount;
+  }
 };
 
 class Tabs extends React.Component {
   constructor(props) {
     super(props);
 
+    this.listRef = React.createRef();
     this.tabButtonRefs = [];
 
-    this.state = getActiveTab(props, {});
+    this.state = getActiveTab(props, {
+      scrollableLeft: false,
+      scrollableRight: false,
+    });
 
-    this.onClick = this.onClick.bind(this);
+    this.onTabClick = this.onTabClick.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
+    this.updateScrollStatus = this.updateScrollStatus.bind(this);
+    this.onScrollButtonClick = this.onScrollButtonClick.bind(this);
   }
 
   static getDerivedStateFromProps(props, state) {
     return getActiveTab(props, state);
+  }
+
+  componentDidMount() {
+    this.updateScrollStatus();
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', this.updateScrollStatus);
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -97,13 +147,30 @@ class Tabs extends React.Component {
     const { activeTab } = this.state;
 
     if (activeTab !== prevActiveTab) {
-      const { activeIndex } = this.state;
-
+      const { activeIndex, scrollableRight, scrollableLeft } = this.state;
       focus(this.tabButtonRefs[activeIndex]);
+
+      if (!scrollableRight && !scrollableLeft) return;
+
+      const { transparent } = this.props;
+      revealTab(
+        this.listRef.current,
+        this.tabButtonRefs[activeIndex],
+        // Tabs with borders should scroll a little further to avoid cutting off
+        // their focus styles and allow for the margins they use at the extreme
+        // left and right:
+        transparent ? 0 : 4,
+      );
     }
   }
 
-  onClick(activeTab) {
+  componentWillUnmount() {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('resize', this.updateScrollStatus);
+    }
+  }
+
+  onTabClick(activeTab) {
     const { onChange } = this.props;
     this.setState({ activeTab });
     onChange(activeTab);
@@ -123,12 +190,41 @@ class Tabs extends React.Component {
     }
   }
 
+  onScrollButtonClick(direction) {
+    if (!this.listRef.current) return;
+
+    const visibleWidth = this.listRef.current.offsetWidth;
+    let scrollAmount = visibleWidth;
+    const { scrollableRight } = this.state;
+
+    if (direction === 'left' && !scrollableRight) {
+      scrollAmount -= SCROLL_BUTTON_WIDTH;
+    }
+
+    this.listRef.current.scrollLeft +=
+      direction === 'left' ? -scrollAmount : scrollAmount;
+  }
+
   getActiveTab(tabsProps) {
     const { activeTab } = this.state;
 
     const activeChild = tabsProps.find(props => props.active);
 
     return (activeChild && activeChild.id) || activeTab;
+  }
+
+  updateScrollStatus() {
+    const { scroll } = this.props;
+    if (!scroll) return;
+
+    this.setState({
+      scrollableLeft: this.listRef.current.scrollLeft > 0,
+      scrollableRight:
+        this.listRef.current.scrollLeft +
+          this.listRef.current.offsetWidth +
+          SCROLL_BUTTON_WIDTH <
+        this.listRef.current.scrollWidth,
+    });
   }
 
   switchTabOnArrowPress(offset) {
@@ -154,6 +250,30 @@ class Tabs extends React.Component {
     }
   }
 
+  renderScrollButton(direction) {
+    const { scrollableLeft, scrollableRight } = this.state;
+    if (
+      (direction === 'left' && scrollableLeft) ||
+      (direction === 'right' && scrollableRight)
+    ) {
+      return (
+        <Button
+          className="rc-tabs-button-scroll"
+          type="transparent"
+          icon={`chevron-${direction}`}
+          onClick={() => this.onScrollButtonClick(direction)}
+          onKeyUp={e => {
+            if (e.keyCode === ENTER_KEY_CODE) {
+              this.onScrollButtonClick(direction);
+            }
+          }}
+        />
+      );
+    }
+
+    return null;
+  }
+
   render() {
     const { activeTab } = this.state;
     const {
@@ -161,6 +281,7 @@ class Tabs extends React.Component {
       className,
       id: parentId,
       panePadding,
+      scroll,
       style,
       transparent,
       type,
@@ -176,25 +297,38 @@ class Tabs extends React.Component {
         className={classNames('rc-tabs', `rc-tabs-${type}`, className, {
           'rc-tabs-pane-padding': panePadding,
           'rc-tabs-transparent': transparent,
+          'rc-tabs-no-scroll': !scroll,
         })}
         style={style}
       >
-        <div className="rc-tabs-list" role="tablist">
-          {tabsProps.map(({ id, children, ...rest }, index) => (
-            <Tab
-              {...rest}
-              key={id}
-              id={id}
-              parentId={parentId}
-              active={activeTab === id}
-              onClick={this.onClick}
-              onKeyDown={this.onKeyDown}
-              ref={button => {
-                this.tabButtonRefs[index] = button;
-              }}
-            />
-          ))}
-          {otherChildren}
+        <div className="rc-tabs-list-container">
+          {this.renderScrollButton('left')}
+          <div
+            className="rc-tabs-list"
+            role="tablist"
+            ref={this.listRef}
+            onScroll={this.updateScrollStatus}
+          >
+            {tabsProps.map(
+              ({ id, children, type: tabType, ...rest }, index) => (
+                <Tab
+                  {...rest}
+                  key={id}
+                  id={id}
+                  parentId={parentId}
+                  active={activeTab === id}
+                  onClick={this.onTabClick}
+                  onKeyDown={this.onKeyDown}
+                  type={tabType || type}
+                  ref={button => {
+                    this.tabButtonRefs[index] = button;
+                  }}
+                />
+              ),
+            )}
+            {otherChildren}
+          </div>
+          {this.renderScrollButton('right')}
         </div>
         {tabsProps.map(({ id, children, type: tabType }) => (
           <Panel

--- a/packages/react-components/source/react/library/tabs/Tabs.js
+++ b/packages/react-components/source/react/library/tabs/Tabs.js
@@ -26,6 +26,8 @@ const propTypes = {
   panePadding: PropTypes.bool,
   /** Optional additional inline style */
   style: PropTypes.shape({}),
+  /** Whether to use the transparent tab design instead of the default outlined tabs */
+  transparent: PropTypes.bool,
   /** Controls background color of active tab */
   type: PropTypes.oneOf(['primary', 'secondary']),
 };
@@ -37,6 +39,7 @@ const defaultProps = {
   onChange() {},
   panePadding: true,
   style: {},
+  transparent: false,
   type: 'primary',
 };
 
@@ -159,6 +162,7 @@ class Tabs extends React.Component {
       id: parentId,
       panePadding,
       style,
+      transparent,
       type,
     } = this.props;
 
@@ -171,6 +175,7 @@ class Tabs extends React.Component {
       <div
         className={classNames('rc-tabs', `rc-tabs-${type}`, className, {
           'rc-tabs-pane-padding': panePadding,
+          'rc-tabs-transparent': transparent,
         })}
         style={style}
       >

--- a/packages/react-components/source/react/library/tabs/Tabs.md
+++ b/packages/react-components/source/react/library/tabs/Tabs.md
@@ -12,6 +12,8 @@ The Tabs component is a lightly styled wrapper that expects nested Tabs. Tab com
 
 ### Primary
 
+The default, primary type gives tabs a white background:
+
 ```jsx
 import Text from '../text';
 
@@ -34,6 +36,8 @@ import Text from '../text';
 
 ### Secondary
 
+If `type=secondary`, tabs change their background color on activation:
+
 ```jsx
 import Button from '../button';
 import Text from '../text';
@@ -50,6 +54,40 @@ import Text from '../text';
       To change the default tab, set the activeTab prop on Tabs equal to the
       desired Tab ID.
     </Text>
+  </Tabs.Tab>
+</Tabs>;
+```
+
+Individual `Tab` components may also set `type=secondary` themselves. See the **Tab** section below.
+
+### Transparent
+
+Set `transparent=true` to use an alternate, borderless tab design:
+
+```
+import Text from '../text';
+
+<Tabs transparent>
+  <Tabs.Tab title="Tab 1">
+    <Text>Tab 1</Text>
+  </Tabs.Tab>
+  <Tabs.Tab title="Tab 2">
+    <Text>Tab 2</Text>
+  </Tabs.Tab>
+</Tabs>;
+```
+
+Example with `type=secondary`:
+
+```
+import Text from '../text';
+
+<Tabs transparent type='secondary'>
+  <Tabs.Tab title="Tab 1">
+    <Text>Tab 1</Text>
+  </Tabs.Tab>
+  <Tabs.Tab title="Tab 2">
+    <Text>Tab 2</Text>
   </Tabs.Tab>
 </Tabs>;
 ```
@@ -127,13 +165,13 @@ import Text from '../text';
 
 <Tabs>
   <Tabs.Tab title="Primary tab">
-    <Text>White background on first tab when type is primary</Text>
+    <Text>Default white background on first tab</Text>
   </Tabs.Tab>
   <Tabs.Tab title="Secondary tab" type="secondary">
-    <Text>Grey background on first tab when type is secondary</Text>
+    <Text>Grey background on second tab, whose type is secondary</Text>
   </Tabs.Tab>
   <Tabs.Tab title="Primary tab" type="primary">
-    <Text>White background on first tab when type is primary</Text>
+    <Text>Default white background on the third tab</Text>
   </Tabs.Tab>
 </Tabs>;
 ```

--- a/packages/react-components/source/react/library/tabs/Tabs.md
+++ b/packages/react-components/source/react/library/tabs/Tabs.md
@@ -92,6 +92,110 @@ import Text from '../text';
 </Tabs>;
 ```
 
+## Responding to smaller container widths
+
+By default, if the row of tabs is too long for its container element, it will be horizontally scrollable, and scroll buttons will be rendered at the left and right as needed:
+
+```
+import Text from '../text';
+
+<div style={{ maxWidth: '300px' }}>
+  <Tabs transparent>
+    <Tabs.Tab title="Tab One" id={1}>
+      <Text>
+        Tab 1 Odio aenean sed adipiscing diam donec adipiscing. Molestie ac feugiat sed lectus. Vitae aliquet nec ullamcorper sit amet risus nullam.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Two" id={2}>
+      <Text>
+        Tab 2 Eu non diam phasellus vestibulum lorem sed risus ultricies tristique. Vitae suscipit tellus mauris a diam maecenas sed.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Three" id={3}>
+      <Text>
+        Tab 3 Tempus iaculis urna id volutpat lacus. Feugiat vivamus at augue eget arcu dictum varius. Sit amet consectetur adipiscing elit pellentesque habitant morbi.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Four" id={4}>
+      <Text>
+        Tab 4 Mattis rhoncus urna neque viverra justo nec ultrices dui. Ultrices mi tempus imperdiet nulla malesuada pellentesque elit eget gravida.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Five" id={5}>
+      <Text>
+        Tab 5 Odio aenean sed adipiscing diam donec adipiscing. Molestie ac feugiat sed lectus. Vitae aliquet nec ullamcorper sit amet risus nullam.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Six" id={6}>
+      <Text>
+        Tab 6 Eu non diam phasellus vestibulum lorem sed risus ultricies tristique. Vitae suscipit tellus mauris a diam maecenas sed.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Seven" id={7}>
+      <Text>
+        Tab 7 Tempus iaculis urna id volutpat lacus. Feugiat vivamus at augue eget arcu dictum varius. Sit amet consectetur adipiscing elit pellentesque habitant morbi.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Eight" id={8}>
+      <Text>
+        Tab 8 Mattis rhoncus urna neque viverra justo nec ultrices dui. Ultrices mi tempus imperdiet nulla malesuada pellentesque elit eget gravida.
+      </Text>
+    </Tabs.Tab>
+  </Tabs>
+</div>;
+```
+
+To disable this behavior, set `scroll=false`. The tab titles will wrap if needed, but content may still be cut off where there is not enough space:
+
+```
+import Text from '../text';
+
+<div style={{ maxWidth: '300px' }}>
+  <Tabs transparent scroll={false}>
+    <Tabs.Tab title="Tab One" id={1}>
+      <Text>
+        Tab 1 Odio aenean sed adipiscing diam donec adipiscing. Molestie ac feugiat sed lectus. Vitae aliquet nec ullamcorper sit amet risus nullam.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Two" id={2}>
+      <Text>
+        Tab 2 Eu non diam phasellus vestibulum lorem sed risus ultricies tristique. Vitae suscipit tellus mauris a diam maecenas sed.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Three" id={3}>
+      <Text>
+        Tab 3 Tempus iaculis urna id volutpat lacus. Feugiat vivamus at augue eget arcu dictum varius. Sit amet consectetur adipiscing elit pellentesque habitant morbi.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Four" id={4}>
+      <Text>
+        Tab 4 Mattis rhoncus urna neque viverra justo nec ultrices dui. Ultrices mi tempus imperdiet nulla malesuada pellentesque elit eget gravida.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Five" id={5}>
+      <Text>
+        Tab 5 Odio aenean sed adipiscing diam donec adipiscing. Molestie ac feugiat sed lectus. Vitae aliquet nec ullamcorper sit amet risus nullam.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Six" id={6}>
+      <Text>
+        Tab 6 Eu non diam phasellus vestibulum lorem sed risus ultricies tristique. Vitae suscipit tellus mauris a diam maecenas sed.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Seven" id={7}>
+      <Text>
+        Tab 7 Tempus iaculis urna id volutpat lacus. Feugiat vivamus at augue eget arcu dictum varius. Sit amet consectetur adipiscing elit pellentesque habitant morbi.
+      </Text>
+    </Tabs.Tab>
+    <Tabs.Tab title="Tab Eight" id={8}>
+      <Text>
+        Tab 8 Mattis rhoncus urna neque viverra justo nec ultrices dui. Ultrices mi tempus imperdiet nulla malesuada pellentesque elit eget gravida.
+      </Text>
+    </Tabs.Tab>
+  </Tabs>
+</div>;
+```
+
 ## Controlled Mode
 
 The active tab can be manually controlled by setting `active=true` on an individual Tab. If more than one tab is marked active, the first active tab will be selected. In this mode we recommend supplying a unique `id` to each Tab element so that the active tab is easier to track. If no id is provided the Tabs component will use the positional index.

--- a/packages/react-components/source/scss/library/components/_tabs.scss
+++ b/packages/react-components/source/scss/library/components/_tabs.scss
@@ -1,3 +1,6 @@
+$scroll-button-size: 32px;
+$bottom-border-shadow: inset 0 -2px 1px -1px $puppet-n400;
+
 // Tabs
 // ----------------------------------------------------------------------------
 .rc-tabs {
@@ -8,29 +11,52 @@
   max-width: 100%;
 }
 
-.rc-tabs-list {
+.rc-tabs-list-container {
   align-items: flex-end;
   display: flex;
-  overflow: visible;
+}
+
+.rc-tabs-list {
+  align-items: flex-end;
+  box-shadow: $bottom-border-shadow;
+  display: flex;
+  min-height: $scroll-button-size + 2; // Accommodate box shadow on focus
+  -ms-overflow-style: none;
+  overflow-x: auto;
+  overflow-y: hidden;
+  position: relative;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  width: 100%;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 // Tab
 .rc-tabs-button {
   border-bottom: 0 !important;
   border-radius: $puppet-common-border-radius $puppet-common-border-radius 0 0 !important;
+  box-shadow: $bottom-border-shadow;
   color: $puppet-type-color-base;
   fill: $puppet-type-color-base;
   margin: 0 2px;
-  margin-left: 2px !important; // override specific default button + button margins
+  margin-left: 2px !important; // override specific default button + button margin
   padding-left: $puppet-common-spacing-base * 6;
   padding-right: $puppet-common-spacing-base * 6;
   position: relative;
+  white-space: nowrap;
+
+  .rc-tabs-no-scroll & {
+    white-space: pre-wrap;
+  }
 
   .rc-tabs-transparent & {
     border: 0;
     margin: 0;
+    margin-left: 0 !important; // override specific default button + button margin
     padding: $puppet-common-spacing-base * 2 $puppet-common-spacing-base * 3;
-    margin-left: 0 !important; // override specific default button + button margins
   }
 
   .rc-tabs-transparent &:focus {
@@ -41,6 +67,10 @@
     align-items: center;
     display: flex;
   }
+}
+
+.rc-button.rc-tabs-button-scroll {
+  z-index: 2;
 }
 
 .rc-tabs-button-active::after {
@@ -76,7 +106,6 @@
 
 // Panel
 .rc-tabs-panel {
-  border-top: $puppet-common-border;
   flex: 1;
   min-height: 0;
   z-index: 1;
@@ -101,8 +130,8 @@
 }
 
 // Secondary coloring
-.rc-tabs-secondary > .rc-tabs-list > .rc-tabs-button-active,
-.rc-tabs-secondary > .rc-tabs-list > .rc-tabs-button-active::after,
+.rc-tabs-secondary .rc-tabs-list > .rc-tabs-button-active,
+.rc-tabs-secondary .rc-tabs-list > .rc-tabs-button-active::after,
 .rc-tabs-secondary > .rc-tabs-panel,
 .rc-tabs-tab-secondary.rc-tabs-button-active,
 .rc-tabs-tab-secondary.rc-tabs-button-active::after,
@@ -112,6 +141,10 @@
 
 // Transparent variant
 .rc-tabs-transparent {
+  &.rc-tabs-secondary .rc-tabs-list > .rc-tabs-button-active {
+    background-color: $puppet-white;
+  }
+
   .rc-tabs-button.rc-tabs-button-active::after {
     background-color: $puppet-b500;
     bottom: 0;

--- a/packages/react-components/source/scss/library/components/_tabs.scss
+++ b/packages/react-components/source/scss/library/components/_tabs.scss
@@ -21,10 +21,21 @@
   color: $puppet-type-color-base;
   fill: $puppet-type-color-base;
   margin: 0 2px;
-  margin-left: 2px !important;
+  margin-left: 2px !important; // override specific default button + button margins
   padding-left: $puppet-common-spacing-base * 6;
   padding-right: $puppet-common-spacing-base * 6;
   position: relative;
+
+  .rc-tabs-transparent & {
+    border: 0;
+    margin: 0;
+    padding: $puppet-common-spacing-base * 2 $puppet-common-spacing-base * 3;
+    margin-left: 0 !important; // override specific default button + button margins
+  }
+
+  .rc-tabs-transparent &:focus {
+    box-shadow: inset 0 0 0 $puppet-common-spacing-base / 2 $puppet-b300;
+  }
 
   .rc-button-content {
     align-items: center;
@@ -44,10 +55,18 @@
 
 .rc-tabs-button:first-of-type {
   margin-left: $puppet-common-spacing-base;
+
+  .rc-tabs-transparent & {
+    margin-left: 0;
+  }
 }
 
 .rc-tabs-button:last-of-type {
   margin-right: $puppet-common-spacing-base;
+
+  .rc-tabs-transparent & {
+    margin-right: 0;
+  }
 }
 
 .rc-tabs-button-active {
@@ -89,4 +108,12 @@
 .rc-tabs-tab-secondary.rc-tabs-button-active::after,
 .rc-tabs-panel-type-secondary {
   background-color: $puppet-n50;
+}
+
+// Transparent variant
+.rc-tabs-transparent {
+  .rc-tabs-button.rc-tabs-button-active::after {
+    background-color: $puppet-b500;
+    bottom: 0;
+  }
 }


### PR DESCRIPTION
Implements changes described by these two Figma files [(1)](https://www.figma.com/file/4TB5H9eFfMWeGaC76Ky7Qs/PDS-New-Component-Designs?node-id=1%3A10) [(2)](https://www.figma.com/file/yTWA69sWZHfy1cpcd4r6Jf/Module-Detail?node-id=1546%3A18561), including:

- A new variant of the Tabs component ('transparent', with no tab borders and a blue underline), and
- Horizontal scrolling for the tab bar when the container is too narrow to fit all of the tabs.

Something about the styleguidist dev server seems not to work with the proxy service I'd normally use to test this across browsers in saucelabs, so I've only been able to confirm that this works on Chrome and Firefox in Linux for now.