### PR TITLE
(PDS-508) Relax Form.Field `description` prop type

### DIFF
--- a/packages/react-components/source/react/library/form/Form.md
+++ b/packages/react-components/source/react/library/form/Form.md
@@ -8,7 +8,7 @@ The `Form` component must be used in conjunction with one or more [`Form.Field`]
 
 ### Uncontrolled (recommended in most cases)
 
-In _uncontrolled_ mode, the Form component tracks field values in internal state. The form may be supplied an initialValues object prop with each field name and its initial value, and a submit handler that is passed the final values. When new `initialValues` are detected, the component is reset (see [error handling](#linkylink) below).
+In _uncontrolled_ mode, the Form component tracks field values in internal state. The form may be supplied an initialValues object prop with each field name and its initial value, and a submit handler that is passed the final values. When new `initialValues` are detected, the component is reset. (See the section on Errors below.)
 
 ```jsx
 const movieOptions = [

--- a/packages/react-components/source/react/library/form/FormField.js
+++ b/packages/react-components/source/react/library/form/FormField.js
@@ -23,8 +23,8 @@ const propTypes = {
   value: PropTypes.any,
   /** Form error, causing element to render red when present */
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  /** Expanded explainer for the field */
-  description: PropTypes.string,
+  /** An optional explanatory message rendered below the form field. */
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /** Is the field required */
   required: PropTypes.bool,
   /** The error message to display if the field is required but not present at validation */


### PR DESCRIPTION
Allow non-strings like links in the descriptions under form fields.

<img width="1273" alt="Screen Shot 2020-09-25 at 7 31 44 PM" src="https://user-images.githubusercontent.com/175123/94328547-5373c880-ff68-11ea-8c83-2677e17bf49f.png">
