### PR TITLE
Rename Sidebar to Navigation but keep alias

### DIFF
--- a/packages/react-components/source/react/library/sidebar/Navigation.js
+++ b/packages/react-components/source/react/library/sidebar/Navigation.js
@@ -5,7 +5,7 @@ import Section from './SidebarSection';
 import Item from './SidebarItem';
 import Footer from './SidebarFooter';
 import Header from './SidebarHeader';
-import Navigation from './SidebarNavigation';
+import SidebarNavigation from './SidebarNavigation';
 import renderChildren from './helper';
 
 const propTypes = {
@@ -23,7 +23,7 @@ const defaultProps = {
   children: [],
 };
 
-const Sidebar = props => {
+const Navigation = props => {
   const { className, minimized, ...rest } = props;
   const classNames = classnames('rc-sidebar', className, {
     'rc-sidebar-minimized': minimized,
@@ -37,13 +37,13 @@ const Sidebar = props => {
   );
 };
 
-Sidebar.propTypes = propTypes;
-Sidebar.defaultProps = defaultProps;
+Navigation.propTypes = propTypes;
+Navigation.defaultProps = defaultProps;
 
-Sidebar.Header = Header;
-Sidebar.Navigation = Navigation;
-Sidebar.Section = Section;
-Sidebar.Item = Item;
-Sidebar.Footer = Footer;
+Navigation.Header = Header;
+Navigation.Navigation = SidebarNavigation;
+Navigation.Section = Section;
+Navigation.Item = Item;
+Navigation.Footer = Footer;
 
-export default Sidebar;
+export default Navigation;

--- a/packages/react-components/source/react/library/sidebar/Sidebar.md
+++ b/packages/react-components/source/react/library/sidebar/Sidebar.md
@@ -1,45 +1,45 @@
 ## Overview
 
-The `Sidebar` component was designed and developed to be used as the primary app navigation. Care has been taken to make sure it is accessible (and if any accessibility issues are discovered, please file a PDS bug.) It is made up of the primary `Sidebar` component but can be composed by using the `Sidebar.Header`, `Sidebar.Navigation`, `Sidebar.Section`, `Sidebar.Item`, and `Sidebar.Footer` components. It does not currently support nesting beyond items in sections.
+The `Navigation` component was designed and developed to be used as the primary app navigation. Care has been taken to make sure it is accessible (and if any accessibility issues are discovered, please file a PDS bug.) It is made up of the primary `Navigation` component but can be composed by using the `Navigation.Header`, `Navigation.Navigation`, `Navigation.Section`, `Navigation.Item`, and `Navigation.Footer` components. It does not currently support nesting beyond items in sections.
 
 ## Basic use
 
-Affix the Sidebar to the left side of the app, stack `Sidebar.Header`, `Sidebar.Navigation`, and `Sidebar.Footer` inside `Sidebar`, and add a `Sidebar.Item` for each navigation item. Multiple `Sidebar.Item` components may optionally be grouped inside `Sidebar.Section` components to add named sections.
+Affix the Navigation to the left side of the app, stack `Navigation.Header`, `Navigation.Navigation`, and `Navigation.Footer` inside `Navigation`, and add a `Navigation.Item` for each navigation item. Multiple `Navigation.Item` components may optionally be grouped inside `Navigation.Section` components to add named sections.
 
-The Sidebar component is stateless so you will need to manage which `Sidebar.Item`
+The Navigation component is stateless so you will need to manage which `Navigation.Item`
 is currently highlighted with the `active` prop or use it with React Router's
 [NavLink](https://reacttraining.com/react-router/web/api/NavLink) component,
 which will apply an `active` class when the URL matches the defined route, e.g.:
 
 ```jsx static
-<Sidebar.Item title="Hello" as={NavLink} to="/hello" />
+<Navigation.Item title="Hello" as={NavLink} to="/hello" />
 ```
 
-Following the `as` pattern in use in many Design System components, you may change `Sidebar.Header` from a button to a link by adding `as="a" href="/"` as shown below or `as={Link} to="/"` if using React Router.
+Following the `as` pattern in use in many Design System components, you may change `Navigation.Header` from a button to a link by adding `as="a" href="/"` as shown below or `as={Link} to="/"` if using React Router.
 
 ```jsx
 import Badge from '../badge';
 
 <div style={{ position: 'relative', height: '500px' }}>
-  <Sidebar>
-    <Sidebar.Header
+  <Navigation>
+    <Navigation.Header
       logo="pipelines"
       ariaLabel="Return to the home page"
       as="a"
       href="/"
     />
-    <Sidebar.Navigation>
-      <Sidebar.Item
+    <Navigation.Navigation>
+      <Navigation.Item
         onClick={() => {}}
         title="Home"
         icon="home"
         active
         containerElement="div"
       />
-      <Sidebar.Section label="reports">
-        <Sidebar.Item onClick={() => {}} title="Code" icon="code" />
-        <Sidebar.Item onClick={() => {}} title="Build" icon="build" count={5} />
-        <Sidebar.Item
+      <Navigation.Section label="reports">
+        <Navigation.Item onClick={() => {}} title="Code" icon="code" />
+        <Navigation.Item onClick={() => {}} title="Build" icon="build" count={5} />
+        <Navigation.Item
           onClick={() => {}}
           title="Deploy"
           icon="rocket"
@@ -49,17 +49,17 @@ import Badge from '../badge';
             </Badge>
           }
         />
-      </Sidebar.Section>
-      <Sidebar.Section label="config">
-        <Sidebar.Item
+      </Navigation.Section>
+      <Navigation.Section label="config">
+        <Navigation.Item
           onClick={() => {}}
           title="Connections"
           icon="connections"
           label="config"
         />
-      </Sidebar.Section>
-    </Sidebar.Navigation>
-    <Sidebar.Footer
+      </Navigation.Section>
+    </Navigation.Navigation>
+    <Navigation.Footer
       profileIcon={
         <img src="https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=100" />
       }
@@ -67,48 +67,48 @@ import Badge from '../badge';
       version="1969.7.20"
       onClick={console.log}
     />
-  </Sidebar>
+  </Navigation>
 </div>;
 ```
 
 ## Variations
 
-### Minimized Sidebar
+### Minimized Navigation
 
-Add the `minimized` boolean prop to Sidebar to render a narrow version with icons and no text for Sidebar items. This may be used for responsive designs on small screens.
+Add the `minimized` boolean prop to Navigation to render a narrow version with icons and no text for Navigation items. This may be used for responsive designs on small screens.
 
 ```jsx
 <div style={{ position: 'relative', height: '500px' }}>
-  <Sidebar minimized>
-    <Sidebar.Header
+  <Navigation minimized>
+    <Navigation.Header
       logo="pipelines"
       onClick={() => console.log('logo clicked')}
       ariaLabel="Return to the home page"
     />
-    <Sidebar.Navigation>
-      <Sidebar.Item
+    <Navigation.Navigation>
+      <Navigation.Item
         onClick={() => {}}
         title="Home"
         icon="home"
         active
         containerElement="div"
       />
-      <Sidebar.Section label="reports">
-        <Sidebar.Item onClick={() => {}} title="Code" icon="code" />
-        <Sidebar.Item onClick={() => {}} title="Build" icon="build" />
-        <Sidebar.Item onClick={() => {}} title="Deploy" icon="rocket" />
-      </Sidebar.Section>
-      <Sidebar.Section label="config">
-        <Sidebar.Item
+      <Navigation.Section label="reports">
+        <Navigation.Item onClick={() => {}} title="Code" icon="code" />
+        <Navigation.Item onClick={() => {}} title="Build" icon="build" />
+        <Navigation.Item onClick={() => {}} title="Deploy" icon="rocket" />
+      </Navigation.Section>
+      <Navigation.Section label="config">
+        <Navigation.Item
           onClick={() => {}}
           title="Connections"
           icon="connections"
           label="config"
         />
-      </Sidebar.Section>
-    </Sidebar.Navigation>
-    <Sidebar.Footer username="Lorem Ipsum" version="1969.7.20" />
-  </Sidebar>
+      </Navigation.Section>
+    </Navigation.Navigation>
+    <Navigation.Footer username="Lorem Ipsum" version="1969.7.20" />
+  </Navigation>
 </div>
 ```
 


### PR DESCRIPTION
@jilliankeenan 
#316 Rename Sidebar to Navigation but keep alias.
Resolves #316.
please comment if any additional changes needed.