### PR TITLE
(PDS-512) Add signout option to Sidebar Footer

### DIFF
--- a/packages/react-components/source/react/library/sidebar/Sidebar.md
+++ b/packages/react-components/source/react/library/sidebar/Sidebar.md
@@ -66,6 +66,8 @@ import Badge from '../badge';
       username="Lorem Ipsum"
       version="1969.7.20"
       onClick={console.log}
+      enableSignout
+      onSignout={console.log}
     />
   </Sidebar>
 </div>;

--- a/packages/react-components/source/react/library/sidebar/SidebarFooter.js
+++ b/packages/react-components/source/react/library/sidebar/SidebarFooter.js
@@ -4,6 +4,8 @@ import Icon from '../icon';
 import Heading from '../heading';
 import Text from '../text';
 import Avatar from '../avatar';
+import classnames from 'classnames';
+import Button from '../button';
 
 const propTypes = {
   /** The root HTML element  */
@@ -16,6 +18,10 @@ const propTypes = {
   minimized: PropTypes.bool,
   /** Displays an element of the users choice * */
   profileIcon: PropTypes.node,
+  /** Boolean flag to enable or disable (default) signout button */
+  enableSignout: PropTypes.bool,
+  /** Signout callback function */
+  onSignout: PropTypes.func,
 };
 
 const defaultProps = {
@@ -24,6 +30,8 @@ const defaultProps = {
   version: '',
   minimized: false,
   profileIcon: null,
+  enableSignout: false,
+  onSignout: () => {},
 };
 
 const SidebarFooter = ({
@@ -32,10 +40,13 @@ const SidebarFooter = ({
   version,
   minimized,
   profileIcon: profileIconProp,
+  enableSignout,
+  onSignout,
   ...rest
 }) => {
   const Component = as;
   let meta;
+  let signout;
 
   if (!minimized) {
     meta = (
@@ -50,15 +61,34 @@ const SidebarFooter = ({
         )}
       </div>
     );
+
+    if (enableSignout) {
+      signout = (
+        <Button
+          className="rc-sidebar-footer-button-signout"
+          onClick={onSignout}
+        >
+          <Icon type="sign-out" className="rc-sidebar-footer-signout-icon" />
+        </Button>
+      );
+    }
   }
 
   return (
-    <Component className="rc-sidebar-footer" {...rest}>
-      <div className="rc-sidebar-footer-meta-user">
-        {profileIconProp || <Avatar>{profileIconProp}</Avatar>}
-      </div>
-      {meta}
-    </Component>
+    <div className="rc-sidebar-footer">
+      <Component
+        className={classnames('rc-sidebar-footer-button-user', {
+          'rc-sidebar-footer-button-minimized': minimized,
+        })}
+        {...rest}
+      >
+        <div className="rc-sidebar-footer-meta-user">
+          {profileIconProp || <Avatar>{profileIconProp}</Avatar>}
+        </div>
+        {meta}
+      </Component>
+      {signout}
+    </div>
   );
 };
 

--- a/packages/react-components/source/react/library/sidebar/SidebarFooter.js
+++ b/packages/react-components/source/react/library/sidebar/SidebarFooter.js
@@ -79,6 +79,7 @@ const SidebarFooter = ({
       <Component
         className={classnames('rc-sidebar-footer-button-user', {
           'rc-sidebar-footer-button-minimized': minimized,
+          'rc-sidebar-footer-clickable': rest.onClick,
         })}
         {...rest}
       >

--- a/packages/react-components/source/react/library/sidebar/SidebarFooter.js
+++ b/packages/react-components/source/react/library/sidebar/SidebarFooter.js
@@ -84,7 +84,11 @@ const SidebarFooter = ({
         {...rest}
       >
         <div className="rc-sidebar-footer-meta-user">
-          {profileIconProp || <Avatar>{profileIconProp}</Avatar>}
+          {profileIconProp ? (
+            <Avatar>{profileIconProp}</Avatar>
+          ) : (
+            <Icon type="profile" className="rc-sidebar-footer-meta-user-icon" />
+          )}
         </div>
         {meta}
       </Component>

--- a/packages/react-components/source/scss/library/components/_avatar.scss
+++ b/packages/react-components/source/scss/library/components/_avatar.scss
@@ -4,13 +4,11 @@
   border-radius: 50%;
   display: flex;
   justify-content: center;
-  margin: $puppet-common-spacing-base;
   text-transform: uppercase;
   background-color: $puppet-n500;
   overflow: hidden;
   height: 32px;
   width: 32px;
-
 
   img {
     width: 100%;

--- a/packages/react-components/source/scss/library/components/_sidebar.scss
+++ b/packages/react-components/source/scss/library/components/_sidebar.scss
@@ -258,6 +258,7 @@ $puppet-sidebar-footer-signout-left-margin: 3px !default;
   .rc-sidebar-footer-button-user {
     flex: 1;
     border: 0;
+    outline: none;
     min-width: 0;
     text-align: left;
     justify-content: flex-start;

--- a/packages/react-components/source/scss/library/components/_sidebar.scss
+++ b/packages/react-components/source/scss/library/components/_sidebar.scss
@@ -51,7 +51,9 @@ $puppet-sidebar-item-accordion-padding: 0 0 0 8px !default;
 
 $puppet-sidebar-footer-height: 72px !default;
 $puppet-sidebar-footer-bg: $puppet-black !default;
-$puppet-sidebar-footer-meta-icon: 32px;
+$puppet-sidebar-footer-meta-icon: 32px !default;
+$puppet-sidebar-footer-signout-width: 56px !default;
+$puppet-sidebar-footer-signout-left-margin: 3px !default;
 
 // Generic sidebar
 
@@ -236,29 +238,66 @@ $puppet-sidebar-footer-meta-icon: 32px;
 // Sidebar footer
 
 .rc-sidebar-footer {
-  @include rc-button-reset();
-  align-items: center;
-  background: $puppet-sidebar-footer-bg;
   box-sizing: border-box;
   display: flex;
   height: $puppet-sidebar-footer-height;
   overflow: hidden;
-  padding: $puppet-sidebar-padding;
-  text-align: left;
   text-decoration: none !important;
+  justify-content: space-between;
+
+  .rc-sidebar-footer-button-user,
+  .rc-sidebar-footer-button-signout {
+    @include rc-button-reset();
+    display: flex;
+    background: $puppet-sidebar-footer-bg;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .rc-sidebar-footer-button-user {
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+    justify-content: flex-start;
+    padding-left: $puppet-sidebar-padding;
+
+    &.rc-sidebar-footer-button-minimized {
+      padding: 0;
+      justify-content: center;
+    }
+  }
+
+  .rc-sidebar-footer-button-signout {
+    width: $puppet-sidebar-footer-signout-width;
+    margin-left: $puppet-sidebar-footer-signout-left-margin;
+  }
 
   .rc-sidebar-footer-meta-username,
   .rc-sidebar-footer-meta-version {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    width: $puppet-sidebar-width - $puppet-sidebar-padding * 3 -
-      $puppet-sidebar-footer-meta-icon;
   }
 }
 
-.rc-sidebar-footer:hover,
-.rc-sidebar-footer:active {
+.rc-sidebar-footer-button-signout:hover,
+.rc-sidebar-footer-button-signout:active {
+  .rc-sidebar-footer-signout-icon {
+    fill: $puppet-sidebar-item-color-hover;
+  }
+}
+
+.rc-sidebar-footer-button-signout:focus {
+  box-shadow: $puppet-common-focus-outline-inset;
+
+  .rc-sidebar-footer-signout-icon {
+    fill: $puppet-sidebar-item-color-hover;
+  }
+}
+
+.rc-sidebar-footer-button-user:hover,
+.rc-sidebar-footer-button-user:active {
   .rc-sidebar-footer-meta-username,
   .rc-sidebar-footer-meta-version {
     color: $puppet-sidebar-item-color-hover;
@@ -269,7 +308,7 @@ $puppet-sidebar-footer-meta-icon: 32px;
   }
 }
 
-.rc-sidebar-footer:focus {
+.rc-sidebar-footer-button-user:focus {
   box-shadow: $puppet-common-focus-outline-inset;
 
   .rc-sidebar-footer-meta-username,
@@ -284,6 +323,8 @@ $puppet-sidebar-footer-meta-icon: 32px;
 
 .rc-sidebar-footer-meta-details {
   display: flex;
+  flex: 1;
+  min-width: 0;
   flex-direction: column;
   margin-left: $puppet-sidebar-padding;
 }

--- a/packages/react-components/source/scss/library/components/_sidebar.scss
+++ b/packages/react-components/source/scss/library/components/_sidebar.scss
@@ -251,6 +251,7 @@ $puppet-sidebar-footer-signout-left-margin: 3px !default;
     display: flex;
     background: $puppet-sidebar-footer-bg;
     height: 100%;
+    border-radius: 0;
     align-items: center;
     justify-content: center;
   }

--- a/packages/react-components/source/scss/library/components/_sidebar.scss
+++ b/packages/react-components/source/scss/library/components/_sidebar.scss
@@ -247,7 +247,6 @@ $puppet-sidebar-footer-signout-left-margin: 3px !default;
 
   .rc-sidebar-footer-button-user,
   .rc-sidebar-footer-button-signout {
-    @include rc-button-reset();
     display: flex;
     background: $puppet-sidebar-footer-bg;
     height: 100%;
@@ -258,10 +257,15 @@ $puppet-sidebar-footer-signout-left-margin: 3px !default;
 
   .rc-sidebar-footer-button-user {
     flex: 1;
+    border: 0;
     min-width: 0;
     text-align: left;
     justify-content: flex-start;
-    padding-left: $puppet-sidebar-padding;
+    padding: 0 0 0 $puppet-sidebar-padding;
+
+    &.rc-sidebar-footer-clickable {
+      cursor: pointer;
+    }
 
     &.rc-sidebar-footer-button-minimized {
       padding: 0;
@@ -270,6 +274,7 @@ $puppet-sidebar-footer-signout-left-margin: 3px !default;
   }
 
   .rc-sidebar-footer-button-signout {
+    @include rc-button-reset();
     width: $puppet-sidebar-footer-signout-width;
     margin-left: $puppet-sidebar-footer-signout-left-margin;
   }
@@ -297,8 +302,8 @@ $puppet-sidebar-footer-signout-left-margin: 3px !default;
   }
 }
 
-.rc-sidebar-footer-button-user:hover,
-.rc-sidebar-footer-button-user:active {
+.rc-sidebar-footer-clickable.rc-sidebar-footer-button-user:hover,
+.rc-sidebar-footer-clickable.rc-sidebar-footer-button-user:active {
   .rc-sidebar-footer-meta-username,
   .rc-sidebar-footer-meta-version {
     color: $puppet-sidebar-item-color-hover;
@@ -309,7 +314,7 @@ $puppet-sidebar-footer-signout-left-margin: 3px !default;
   }
 }
 
-.rc-sidebar-footer-button-user:focus {
+.rc-sidebar-footer-clickable.rc-sidebar-footer-button-user:focus {
   box-shadow: $puppet-common-focus-outline-inset;
 
   .rc-sidebar-footer-meta-username,

--- a/packages/react-components/test/sidebar/Sidebar.js
+++ b/packages/react-components/test/sidebar/Sidebar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
@@ -110,6 +111,24 @@ describe('<Sidebar />', () => {
       const wrapper = shallow(<Sidebar.Footer />);
 
       expect(wrapper.length).to.eql(1);
+      expect(wrapper.find('.rc-sidebar-footer-button-signout').length).to.eql(
+        0,
+      );
+    });
+
+    it('should render signout button', () => {
+      const callback = sinon.fake();
+      const wrapper = shallow(
+        <Sidebar.Footer enableSignout onSignout={callback} />,
+      );
+
+      expect(wrapper.find('.rc-sidebar-footer-button-signout').length).to.eql(
+        1,
+      );
+
+      expect(callback.callCount).to.eql(0);
+      wrapper.find('.rc-sidebar-footer-button-signout').simulate('click');
+      expect(callback.calledOnce).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Add  2 new props to turn on signout in the SidebarFooter:
- enableSignout. This boolean controls rendering a button with the `sign-out` icon.
- onSignout. This is the callback function that gets called when the signout button is clicked.

Note: After discussing this feature with @catrayburn, there are plans to move away from the current approach of the minimized Sidebar design, so I have deliberately not implemented a signout option when the Sidebar is minimized.

<img width="327" alt="Screenshot 2020-10-14 at 17 15 46" src="https://user-images.githubusercontent.com/25032341/96016666-eb1a5780-0e40-11eb-821f-c272c59d7c9c.png">
