### PR TITLE
fix toolbar tabs alignment bug

### DIFF
--- a/packages/react-components/source/scss/library/components/_toolbar.scss
+++ b/packages/react-components/source/scss/library/components/_toolbar.scss
@@ -27,7 +27,12 @@
 }
 
 .rc-toolbar > .rc-tabs > .rc-tabs-list {
+  align-items: normal;
   z-index: 2;
+}
+
+.rc-toolbar > .rc-tabs > .rc-tabs-list-container > .rc-tabs-list {
+  align-items: normal;
 }
 
 .rc-toolbar-primary .rc-tabs-list {


### PR DESCRIPTION
before:
![Screen Shot 2020-10-14 at 2 14 05 PM](https://user-images.githubusercontent.com/29243259/96046154-e09f9400-0e27-11eb-89de-09bda1ef0eaa.png)

after:
![Screen Shot 2020-10-14 at 2 13 52 PM](https://user-images.githubusercontent.com/29243259/96046176-e8f7cf00-0e27-11eb-80b3-b27c10e12d00.png)
