### PR TITLE
Make form field labels visibility hidden when null

### DIFF
--- a/packages/react-components/source/react/library/form/FormField.js
+++ b/packages/react-components/source/react/library/form/FormField.js
@@ -45,6 +45,8 @@ const propTypes = {
   className: PropTypes.string,
   /** Optional additional className for inner field */
   innerClassName: PropTypes.string,
+  /** Optional placeholder to use as label substitute */
+  placeholder: PropTypes.string,
   /** Optional additional inline styles */
   style: PropTypes.shape({}),
   /** All additional props are propagated to the inner input elements. See each option for details. TODO: figure out how to get this set up in styleguidist */
@@ -66,6 +68,7 @@ const defaultProps = {
   className: '',
   innerClassName: '',
   style: {},
+  placeholder: '',
 };
 
 /**
@@ -123,6 +126,7 @@ const FormField = props => {
     name,
     style,
     type,
+    placeholder,
   } = props;
   const typeName = getTypeName(type);
   const tabbed = inline && (type === 'checkbox' || type === 'switch');
@@ -156,11 +160,12 @@ const FormField = props => {
           className={classNames(
             'rc-form-field-label',
             `rc-form-field-label-${labelType}`,
+            !label && `rc-form-field-label-not-visible`,
           )}
           key="field-label"
           style={labelStyle}
         >
-          {label}
+          {label || placeholder || description}
         </label>
         <div className="rc-form-field-element">
           {element}

--- a/packages/react-components/source/scss/library/components/forms/_forms.scss
+++ b/packages/react-components/source/scss/library/components/forms/_forms.scss
@@ -89,6 +89,17 @@ $puppet-form-inline-label-gutter-width: $puppet-common-spacing-base * 12 !defaul
     @include puppet-type-h6(medium);
     font-weight: $puppet-type-weight-heavy;
   }
+
+  &.rc-form-field-label-not-visible {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+  }
 }
 
 .rc-form-field-description {


### PR DESCRIPTION
When `label` prop is empty string or null

1. set the created label styles to be visibility hidden with no height, width or margin
2. use `placeholder` then `description` as replacement `label` values in that order