### PR TITLE
(PDS-556) Updates to the select component

### DIFF
--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuListItem.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuListItem.js
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import Icon from '../../library/icon';
+import Text from '../../library/text';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -15,17 +16,38 @@ const propTypes = {
   svg: PropTypes.element,
   onClick: PropTypes.func.isRequired,
   onMouseEnter: PropTypes.func.isRequired,
+  /** Optional: Causes the text of option items to be strong and include the description  */
+  isDescriptionMenu: PropTypes.bool,
+  /** Optional: The text which is shown besides an options label */
+  description: PropTypes.string,
+  /** Optional: used to ensure correct styling when a menulist includes grouped data */
+  isGroupedMenu: PropTypes.bool,
 };
 
 const defaultProps = {
   icon: null,
   svg: null,
+  description: null,
+  isDescriptionMenu: false,
+  isGroupedMenu: false,
 };
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 const OptionMenuListItem = forwardRef(
   (
-    { id, children, focused, selected, icon, svg, onClick, onMouseEnter },
+    {
+      id,
+      children,
+      focused,
+      selected,
+      icon,
+      svg,
+      description,
+      onClick,
+      onMouseEnter,
+      isDescriptionMenu,
+      isGroupedMenu,
+    },
     ref,
   ) => (
     <li
@@ -34,6 +56,7 @@ const OptionMenuListItem = forwardRef(
       className={classNames('rc-menu-list-item', {
         'rc-menu-list-item-focused': focused,
         'rc-menu-list-item-selected': selected,
+        'rc-menu-list-item-grouped': isGroupedMenu,
       })}
       aria-selected={selected}
       onClick={onClick}
@@ -42,7 +65,16 @@ const OptionMenuListItem = forwardRef(
     >
       {icon && <Icon className="rc-menu-list-item-icon" type={icon} />}
       {svg && !icon && <Icon className="rc-menu-list-item-icon" svg={svg} />}
-      <span className="rc-menu-list-item-content">{children}</span>
+      {isDescriptionMenu ? (
+        <div className="rc-menu-list-item-content-container">
+          <Text size="small">
+            <strong>{children}</strong>
+          </Text>{' '}
+          <span className="rc-menu-list-item-description">{description}</span>
+        </div>
+      ) : (
+        <span className="rc-menu-list-item-content">{children}</span>
+      )}
       {selected && (
         <Icon
           className="rc-menu-list-item-checkmark"

--- a/packages/react-components/source/react/library/select/Select.js
+++ b/packages/react-components/source/react/library/select/Select.js
@@ -17,23 +17,27 @@ import {
 const SELECT = 'select';
 const MULTISELECT = 'multiselect';
 const AUTOCOMPLETE = 'autocomplete';
+const TEXTSELECT = 'textselect';
 
 const propTypes = {
   /** Unique id */
   name: PropTypes.string.isRequired,
   /** An Array of select options */
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      /** Select option value */
-      value: PropTypes.string.isRequired,
-      /** Select option label */
-      label: PropTypes.string.isRequired,
-      /** Optional icon associated with this option */
-      icon: PropTypes.oneOf(Icon.AVAILABLE_ICONS),
-      /** Optional custom icon associated with this option */
-      svg: PropTypes.element,
-    }),
-  ),
+  options: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        /** Select option value */
+        value: PropTypes.string.isRequired,
+        /** Select option label */
+        label: PropTypes.string.isRequired,
+        /** Optional icon associated with this option */
+        icon: PropTypes.oneOf(Icon.AVAILABLE_ICONS),
+        /** Optional custom icon associated with this option */
+        svg: PropTypes.element,
+      }),
+    ),
+    PropTypes.object,
+  ]),
   /** Currently selected value or values */
   value: PropTypes.oneOfType([
     //eslint-disable-line
@@ -50,7 +54,7 @@ const propTypes = {
   /** Text rendered when no value is selected */
   placeholder: PropTypes.string,
   /** Select or autocomplete. Multiselection is NOT yet fully supported */
-  type: PropTypes.oneOf([SELECT, AUTOCOMPLETE, MULTISELECT]),
+  type: PropTypes.oneOf([SELECT, AUTOCOMPLETE, MULTISELECT, TEXTSELECT]),
   /**
    * Text to render as the action label in multiple mode
    * @ignore
@@ -76,6 +80,14 @@ const propTypes = {
   open: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /** onBlur handler */
   onBlur: PropTypes.func,
+  /** Optional additional className passed to the outer menu list element */
+  menuListClassName: PropTypes.string,
+  /** Boolean that when true will render a navigation button in the dropdown */
+  navigationButton: PropTypes.bool,
+  /** Function called when navigation button is pressed */
+  onNavigate: PropTypes.func,
+  /** Text displayed on the navigation button */
+  navigationLabel: PropTypes.string,
 };
 
 const defaultProps = {
@@ -96,6 +108,10 @@ const defaultProps = {
   style: {},
   open: null,
   onBlur() {},
+  menuListClassName: '',
+  navigationButton: false,
+  onNavigate: () => {},
+  navigationLabel: '',
 };
 
 const isControlled = ({ type, applyImmediately }) =>
@@ -296,6 +312,16 @@ class Select extends Component {
       return selectedOptions.join(', ');
     }
 
+    if (typeof options === 'object' && !Array.isArray(options)) {
+      let x = {};
+      const optionTitles = Object.keys(options);
+      optionTitles.forEach(option => {
+        if (options[option].find(w => w.value === value)) {
+          x = options[option].find(w => w.value === value);
+        }
+      });
+      return x.label;
+    }
     const selectedOption = options.find(option => option.value === value);
 
     return selectedOption.label;
@@ -372,6 +398,10 @@ class Select extends Component {
       applyImmediately,
       required,
       footer,
+      menuListClassName,
+      navigationButton,
+      onNavigate,
+      navigationLabel,
     } = this.props;
 
     let input;
@@ -420,6 +450,7 @@ class Select extends Component {
               value={getButtonLabel()}
               placeholder={placeholder}
               aria-label={placeholder}
+              type={type}
               ref={button => {
                 this.button = button;
               }}
@@ -472,6 +503,10 @@ class Select extends Component {
             this.menu = menu;
           }}
           tabIndex={type === AUTOCOMPLETE ? -1 : 0}
+          className={menuListClassName}
+          navigationButton={navigationButton}
+          onNavigate={onNavigate}
+          navigationLabel={navigationLabel}
         />
       </div>
     );

--- a/packages/react-components/source/react/library/select/Select.md
+++ b/packages/react-components/source/react/library/select/Select.md
@@ -24,15 +24,12 @@ const options = [
   { value: 'ca', label: 'Catalan' },
 ];
 
-const style = { margin: 10 };
-
 <div>
   <Select
     id="button-select-one"
     name="select-example"
     options={options}
     placeholder="Select your language"
-    style={style}
     value={state.value1}
     onChange={value1 => {
       console.log('New Value:', value1);
@@ -207,6 +204,140 @@ const options = [
       console.log('New Value:', value);
       setState({ value });
     }}
+  />
+</div>;
+```
+
+### Descriptions
+
+When the option item's within a particular list requires further explanation a description property can be used.
+
+```jsx
+const options = [
+  {
+    value: 'en',
+    label: 'English',
+    description: 'The worlds most common language',
+  },
+  { value: 'ru', label: 'русский' },
+  {
+    value: 'zh',
+    label: '中文',
+    description: 'About 1.2 billion people speak Chinese ',
+  },
+  { value: 'sq', label: 'Albanian' },
+  { value: 'ar', label: 'Arabic' },
+  { value: 'eu', label: 'Basque' },
+  { value: 'bn', label: 'Bengali' },
+  { value: 'bs', label: 'Bosnian' },
+  { value: 'bg', label: 'Bulgarian' },
+  { value: 'ca', label: 'Catalan' },
+];
+
+<div>
+  <Select
+    id="button-select-one"
+    name="select-example"
+    options={options}
+    placeholder="Select your language"
+    value={state.value1}
+    onChange={value1 => {
+      console.log('New Value:', value1);
+      setState({ value1 });
+    }}
+  />
+</div>;
+```
+
+### Grouping
+
+List's of menu options can be broken up into multiple group's in order to make the list easier to read
+
+```jsx
+const options = {
+  Dogs: [
+    { value: 'gs', label: 'German Shepherd' },
+    { value: 'bd', label: 'Bulldog' },
+  ],
+  Cats: [
+    { value: 'p', label: 'Persian' },
+    { value: 's', label: 'Sphynx' },
+  ],
+};
+
+<div>
+  <Select
+    id="button-select-one"
+    name="select-example"
+    options={options}
+    placeholder="Select your animal"
+    value={state.value1}
+    onChange={value1 => {
+      console.log('New Value:', value1);
+      setState({ value1 });
+    }}
+  />
+</div>;
+```
+
+### Custom Navigation
+
+```jsx
+const options = {
+  'Favorite views': [
+    {
+      value: 'a',
+      label: '(Default View)',
+      description: 'No saved view displayed',
+    },
+    {
+      value: 'b',
+      label: 'A view name lorem',
+      description:
+        'Description lorem ipsumus lorem ip lorem ipsumus lorem ip lorem ipsumus lorem ip',
+    },
+    {
+      value: 'c',
+      label: 'View name E',
+      description: 'This is page E',
+    },
+    { value: 'd', label: 'View name G' },
+    {
+      value: 'f',
+      label: 'View name H',
+      description: 'This is page H',
+    },
+  ],
+  'Other views': [
+    {
+      value: 'g',
+      label: 'View name A',
+      description:
+        'Description lorem ipsumus lorem ip lorem ipsumus lorem ip lorem ipsumus lorem ip',
+    },
+    { value: 'h', label: 'View name B' },
+  ],
+};
+
+const onchange = () => {
+  console.log('Lets go to another page');
+};
+
+<div>
+  <Select
+    id="button-select-one"
+    type="textselect"
+    name="select-example"
+    options={options}
+    placeholder="Select your View"
+    value={state.value1}
+    onChange={value1 => {
+      console.log('New Value:', value1);
+      setState({ value1 });
+    }}
+    navigationButton
+    onNavigate={() => onchange()}
+    navigationLabel="Show all saved views"
   />
 </div>;
 ```

--- a/packages/react-components/source/react/library/select/SelectTarget.js
+++ b/packages/react-components/source/react/library/select/SelectTarget.js
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import Icon from '../icon';
+import Button from '../button';
 
 const propTypes = {};
 
@@ -18,23 +19,26 @@ const renderText = (type, value, placeholder) => {
 const SelectTarget = forwardRef(
   ({ error, value, type, placeholder, className, ...rest }, ref) => (
     <div className={classNames('rc-input-container', 'rc-select-target')}>
-      <button
-        type="button"
+      <Button
+        type={type === 'textselect' ? 'text' : null}
         className={classNames('rc-input', {
           'rc-input-error': error,
           'rc-input-empty': !value,
+          'rc-input-text-select': type === 'textselect',
         })}
         ref={ref}
         {...rest}
       >
         <Icon
-          className="rc-input-icon trailing"
+          className={classNames('rc-input-icon trailing', {
+            'rc-input-icon-text-select': type === 'textselect',
+          })}
           width="16px"
           height="16px"
           type="chevron-down"
         />
         {renderText(type, value, placeholder)}
-      </button>
+      </Button>
     </div>
   ),
 );

--- a/packages/react-components/source/scss/library/components/_menu-list.scss
+++ b/packages/react-components/source/scss/library/components/_menu-list.scss
@@ -8,6 +8,11 @@
   overflow: hidden;
 }
 
+.rc-input {
+  font-family: $puppet-type-font-family;
+  font-weight: $puppet-type-weight-normal;
+}
+
 .rc-action-menu-list,
 .rc-option-menu-list-single {
   &:focus-within {
@@ -24,6 +29,16 @@
   .rc-menu-action:focus {
     box-shadow: $puppet-common-focus-outline-inset;
   }
+}
+
+.rc-input-text-select {
+  color: $puppet-type-color-link;
+  font-weight: $puppet-type-weight-heavy;
+  width: fit-content;
+}
+
+.rc-input-icon-text-select {
+  fill: $puppet-type-color-link !important;
 }
 
 .rc-menu-action-container {
@@ -64,6 +79,15 @@
   padding: $puppet-common-spacing-base;
 }
 
+.rc-option-menu-list-title-item {
+  border-bottom: $puppet-common-border;
+  padding: 4px 8px;
+
+  &:not(:first-of-type) {
+    padding: 12px 0 4px 8px;
+  }
+}
+
 .rc-menu-list-item {
   @include puppet-type-small();
 
@@ -91,10 +115,29 @@
   }
 }
 
+.rc-menu-list-item-grouped {
+  margin-left: 8px;
+}
+
 .rc-menu-list-item-content {
   display: flex;
   flex: 1;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rc-menu-list-item-content-container {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rc-menu-list-item-description {
+  overflow: hidden;
+  padding-left: 5px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }


### PR DESCRIPTION
What has been added/changed:
- A description can be added to each list item
- A new button at the bottom of the select dropdown called the navigationbutton has been added, this has it's own callback and label prop
- A new type of select "text select" has been added. This is for use when the select is a title of subtitle of a page. 
- Grouping a select list can now be done by simply passing an object into the options prop instead of an array
- The select target is now using the design systems own button component to render the text select. 
