### PR TITLE
(maint) Fix ability to npm link react-components

### DIFF
--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -16437,15 +16437,6 @@
 			"integrity": "sha1-mUWygD8hni96ygCtuLyfZA+ELJo=",
 			"dev": true
 		},
-		"rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.1.3"
-			}
-		},
 		"ripemd160": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -70,7 +70,6 @@
     "react-router": "^5.2.0",
     "react-styleguidist": "^10.6.2",
     "resolve-url-loader": "^3.1.1",
-    "rimraf": "^3.0.2",
     "sass-loader": "^8.0.2",
     "sinon": "^7.5.0",
     "sinon-chai": "^3.5.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "link": "npm link",
     "analyze": "webpack --config webpack.analyze.config.js",
-    "prebuild": "rimraf build",
     "build": "NODE_ENV=production webpack",
     "prepare": "npm run build",
     "complexity": "es6-plato -r -d complexity source/react && open ./complexity/index.html",


### PR DESCRIPTION
Prior to this commit, @puppet/react-components made use of the npm step
`prebuild` to delete the build directory prior to rebuilding the app.
If another development environment was consuming a linked version of
@puppet/react-components, this prebuild step caused the consuming
application to rebuild immediately, and crash because the build dir was
gone.

With this commit, we remove the prebuild step entirely. As of Webpack 4,
deleting the build dir is no longer necessary. Webpack deletes the
the dir itself when adding the new files. This allows all consuming apps
to utilize the linked version of @puppet/react-components during
develoment.

**Note:**
This is the only package within the design system that used the prebuild
step. I would expect linking to work as-is for all other packages,
though I did not test them.