### PR TITLE
(PDS-565) Allow values that are objects in OptionMenuList

### DIFF
--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
@@ -20,7 +20,7 @@ import Icon from '../../library/icon';
 export const valueType = PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.shape({
-    key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   }),
 ]);
 

--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
@@ -17,21 +17,25 @@ import {
 import OptionMenuListItem from './OptionMenuListItem';
 import Icon from '../../library/icon';
 
+export const valueType = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.shape({
+    key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  }),
+]);
+
 const propTypes = {
   id: PropTypes.string.isRequired,
   multiple: PropTypes.bool,
   showCancel: PropTypes.bool,
   options: PropTypes.arrayOf(
     PropTypes.shape({
-      value: PropTypes.string.isRequired,
+      value: valueType.isRequired,
       label: PropTypes.node.isRequired,
       icon: PropTypes.oneOf(Icon.AVAILABLE_ICONS),
     }),
   ),
-  selected: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
-  ]),
+  selected: PropTypes.oneOfType([valueType, PropTypes.arrayOf(valueType)]),
   focusedIndex: PropTypes.number,
   actionLabel: PropTypes.string,
   cancelLabel: PropTypes.string,
@@ -344,23 +348,27 @@ class OptionMenuList extends Component {
         }}
         {...rest}
       >
-        {options.map(({ value, label, icon, svg }, index) => (
-          <OptionMenuListItem
-            id={getOptionId(id, value)}
-            key={value}
-            focused={index === focusedIndex}
-            selected={selectionSet.has(value)}
-            icon={icon}
-            svg={svg}
-            onClick={() => onClickItem(value)}
-            onMouseEnter={() => onMouseEnterItem(index)}
-            ref={option => {
-              this.optionRefs[index] = option;
-            }}
-          >
-            {label}
-          </OptionMenuListItem>
-        ))}
+        {options.map(({ value, label, icon, svg }, index) => {
+          let key = value;
+          if (!(typeof value === 'string')) key = value.key;
+          return (
+            <OptionMenuListItem
+              id={getOptionId(id, value)}
+              key={key}
+              focused={index === focusedIndex}
+              selected={selectionSet.has(value)}
+              icon={icon}
+              svg={svg}
+              onClick={() => onClickItem(value)}
+              onMouseEnter={() => onMouseEnterItem(index)}
+              ref={option => {
+                this.optionRefs[index] = option;
+              }}
+            >
+              {label}
+            </OptionMenuListItem>
+          );
+        })}
       </ul>
     );
 

--- a/packages/react-components/source/react/library/select/Select.js
+++ b/packages/react-components/source/react/library/select/Select.js
@@ -13,6 +13,7 @@ import {
   UP_KEY_CODE,
   ESC_KEY_CODE,
 } from '../../constants';
+import { valueType } from '../../internal/option-menu-list/OptionMenuList';
 
 const SELECT = 'select';
 const MULTISELECT = 'multiselect';
@@ -25,7 +26,7 @@ const propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       /** Select option value */
-      value: PropTypes.string.isRequired,
+      value: valueType.isRequired,
       /** Select option label */
       label: PropTypes.string.isRequired,
       /** Optional icon associated with this option */
@@ -37,8 +38,8 @@ const propTypes = {
   /** Currently selected value or values */
   value: PropTypes.oneOfType([
     //eslint-disable-line
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
+    valueType,
+    PropTypes.arrayOf(valueType),
   ]),
   /** Value change handler. Will receive the new value */
   onChange: PropTypes.func,

--- a/packages/react-components/source/react/library/select/Select.md
+++ b/packages/react-components/source/react/library/select/Select.md
@@ -9,6 +9,7 @@ The Select component is a form element allowing for selection of a value or set 
 ## Basic use
 
 Options are specified by entries in an `options` array prop. Each requires a unique value and a friendly label to display to users.
+The value can be a string or an object. If it's an object, be sure it has a `key` field. This will be passed in as the React key for the list item.
 
 ```jsx
 const options = [
@@ -21,7 +22,10 @@ const options = [
   { value: 'bn', label: 'Bengali' },
   { value: 'bs', label: 'Bosnian' },
   { value: 'bg', label: 'Bulgarian' },
-  { value: 'ca', label: 'Catalan' },
+  {
+    value: { key: 'ca', code: 'ca', related: ['latin', 'spanish'] },
+    label: 'Catalan',
+  },
 ];
 
 const style = { margin: 10 };


### PR DESCRIPTION
In Arrowhead, we'd much like the ability to pass objects as values in our Select menus for the Add a Project page. This is because when you're selecting things in this particular form, you're not just selecting the name of something or a string, you're selecting an object that has many properties, all of which are required to get the next list of things. So instead of needing to take the selected string and go back to a list of objects to find the one we want, let's just allow the selection of objects directly in the component.

This change just adds PropTypes.shape({ key: ... }) with a key prop included to the 'value' prop, because when OptionMenuList renders the list, it uses the value as the React key but in the case of an object, we still need to have a key to give it.