### PR TITLE
(PDS-575) Adding the ability to choose the cancel button type similar to the current submit type prop

### DIFF
--- a/packages/react-components/source/react/library/form/Form.js
+++ b/packages/react-components/source/react/library/form/Form.js
@@ -40,6 +40,8 @@ const propTypes = {
   cancellable: PropTypes.bool,
   /** Optional override for the cancel button label */
   cancelLabel: PropTypes.string,
+  /** Optional override for the cancel button type */
+  cancelType: PropTypes.oneOf(['secondary', 'tertiary', 'transparent', 'text']),
   /** Cancel event handler */
   onCancel: PropTypes.func,
   /** The styling of the identifier for all fields */
@@ -71,6 +73,7 @@ const defaultProps = {
   onSubmit() {},
   cancellable: false,
   cancelLabel: 'Cancel',
+  cancelType: 'tertiary',
   onCancel() {},
   onChange() {},
   submitting: false,
@@ -96,6 +99,7 @@ const Form = forwardRef((props, ref) => {
     submitType,
     cancellable,
     cancelLabel,
+    cancelType,
     onCancel,
     actionsPosition,
     disabled,
@@ -185,6 +189,7 @@ const Form = forwardRef((props, ref) => {
         submitType={submitType}
         cancellable={cancellable}
         cancelLabel={cancelLabel}
+        cancelType={cancelType}
         onCancel={onCancel}
         actionsPosition={actionsPosition}
         disabled={disabled}

--- a/packages/react-components/source/react/library/form/internal/FormActions.js
+++ b/packages/react-components/source/react/library/form/internal/FormActions.js
@@ -12,6 +12,7 @@ const propTypes = {
   submitType: PropTypes.oneOf(['primary', 'secondary', 'danger']),
   cancellable: PropTypes.bool,
   cancelLabel: PropTypes.string,
+  cancelType: PropTypes.oneOf(['secondary', 'tertiary', 'transparent', 'text']),
   onCancel: PropTypes.func,
   actionsPosition: PropTypes.oneOf(['left', 'right', 'block']),
   disabled: PropTypes.bool,
@@ -26,6 +27,7 @@ const defaultProps = {
   submitType: 'primary',
   cancellable: false,
   cancelLabel: 'Cancel',
+  cancelType: 'tertiary',
   onCancel() {},
   submitting: false,
   actionsPosition: 'left',
@@ -40,6 +42,7 @@ const FormActions = ({
   submitType,
   cancellable,
   cancelLabel,
+  cancelType,
   onCancel,
   actionsPosition,
   disabled,
@@ -66,7 +69,7 @@ const FormActions = ({
     <Button
       key="cancel"
       className="rc-form-action"
-      type="tertiary"
+      type={cancelType}
       onClick={onCancel}
     >
       {cancelLabel}

--- a/packages/react-components/source/react/library/tag/Tag.js
+++ b/packages/react-components/source/react/library/tag/Tag.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { func, string, oneOf, bool } from 'prop-types';
+import { func, string, oneOf, bool, node } from 'prop-types';
 import classNames from 'classnames';
 import Button from '../button';
 import Text from '../text';
 
 const propTypes = {
   /** Tag text or other content */
-  label: string.isRequired,
+  label: node.isRequired,
   /** Callback function called when clode icon is clicked */
   onClick: func,
   /** Type dictates tag coloring */

--- a/packages/react-components/source/react/library/tag/Tag.js
+++ b/packages/react-components/source/react/library/tag/Tag.js
@@ -57,7 +57,7 @@ const Tag = ({
           onClick={() => onClick()}
           icon="close"
           iconSize="small"
-          aria-label={`${label} Remove tag`}
+          aria-label="Remove tag"
         />
       )}
     </div>


### PR DESCRIPTION
This PR covers the addition of the propType cancelType will allow the user of the component to choose the button type for the cancel button. This PR also changes the label type of the tag component to type node as it can be used to render an icon or html element instead of just a string.