### PR TITLE
(MAINT) Change button select to accept string and number values

### DIFF
--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
@@ -24,7 +24,8 @@ const propTypes = {
   showCancel: PropTypes.bool,
   options: PropTypes.arrayOf(
     PropTypes.shape({
-      value: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        .isRequired,
       label: PropTypes.node.isRequired,
       icon: PropTypes.oneOf(Icon.AVAILABLE_ICONS),
       disabled: PropTypes.bool,
@@ -32,6 +33,7 @@ const propTypes = {
   ),
   selected: PropTypes.oneOfType([
     PropTypes.string,
+    PropTypes.number,
     PropTypes.arrayOf(PropTypes.string),
   ]),
   focusedIndex: PropTypes.number,

--- a/packages/react-components/source/react/library/button-select/ButtonSelect.js
+++ b/packages/react-components/source/react/library/button-select/ButtonSelect.js
@@ -34,10 +34,11 @@ const propTypes = {
   ),
   /** Currently selected value or values */
   value: PropTypes.oneOfType([
-    //eslint-disable-line
     PropTypes.string,
     PropTypes.number,
-    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    ),
   ]),
   /** Value change handler. This function gets passed the new value as the only parameter. */
   onChange: PropTypes.func,

--- a/packages/react-components/source/react/library/button-select/ButtonSelect.js
+++ b/packages/react-components/source/react/library/button-select/ButtonSelect.js
@@ -20,7 +20,8 @@ const propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       /** Select option value */
-      value: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        .isRequired,
       /** Select option label */
       label: PropTypes.string.isRequired,
       /** Optional alternate label rendered in the main button element if the option is selected. */
@@ -35,6 +36,7 @@ const propTypes = {
   value: PropTypes.oneOfType([
     //eslint-disable-line
     PropTypes.string,
+    PropTypes.number,
     PropTypes.arrayOf(PropTypes.string),
   ]),
   /** Value change handler. This function gets passed the new value as the only parameter. */

--- a/packages/react-components/test/drawer/Drawer.js
+++ b/packages/react-components/test/drawer/Drawer.js
@@ -48,7 +48,6 @@ describe('<Drawer/>', () => {
     wrapper.find('Button').simulate('click');
     expect(wrapper.find('Button').text()).to.equal(showLess);
 
-    console.log(wrapper.debug());
     expect(wrapper.find('div.rc-drawer-header-content').text()).to.equal(
       'Here is where I make you aware that theres more content to see ',
     );


### PR DESCRIPTION
On the comply team we have a use case where the button select is a list of number values. This causes a lot of console errors across many of the pages but i believe its a valid use case. This pr updates the proptypes to accept both numbers and strings

![Screenshot 2021-03-08 at 10 37 09](https://user-images.githubusercontent.com/30826846/110310302-4ae4eb00-7ffa-11eb-9d04-948e78dfd684.png)
