### PR TITLE
Use min-width and min-height in Card examples

### DIFF
--- a/packages/react-components/source/react/library/card/Card.md
+++ b/packages/react-components/source/react/library/card/Card.md
@@ -10,7 +10,7 @@ import Text from '../text';
 
 const cardExampleStyle = {
   width: 150,
-  height: 150,
+  minHeight: 100,
   alignItems: 'center',
   justifyContent: 'center',
   marginRight: 12,
@@ -40,7 +40,7 @@ import Text from '../text';
 
 const cardExampleStyle = {
   width: 150,
-  height: 150,
+  minHeight: 100,
   alignItems: 'center',
   justifyContent: 'center',
   marginRight: 12,
@@ -75,7 +75,7 @@ initialState = {
 
 const cardExampleStyle = {
   width: 150,
-  height: 150,
+  minHeight: 100,
   alignItems: 'center',
   justifyContent: 'center',
   marginRight: 12,


### PR DESCRIPTION
@steveax pointed out a11y issues with fixed Card sizing: [WCAG 2.1 Success Criterion 1.4.4: Resize text](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html)