### PR TITLE
(PDS-584) Overlay component

### DIFF
--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -2504,6 +2504,16 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@popperjs/core": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.1.tgz",
+			"integrity": "sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA=="
+		},
+		"@puppet/sass-variables": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/@puppet/sass-variables/-/sass-variables-1.4.4.tgz",
+			"integrity": "sha512-yaXg5PmfWQYbGOO6CgYDDy0MGuhVSZchyF4+Ona4YfGgbFfTTT6aKAf/qK9dkMaylXHYnpbO/SWBWhv6y1eQgQ=="
+		},
 		"@sinonjs/commons": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -15156,6 +15166,11 @@
 			"integrity": "sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw==",
 			"dev": true
 		},
+		"react-fast-compare": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+			"integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+		},
 		"react-group": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/react-group/-/react-group-3.0.2.tgz",
@@ -15193,6 +15208,15 @@
 				"prop-types": "^15.5.10",
 				"react-lifecycles-compat": "^3.0.0",
 				"warning": "^4.0.3"
+			}
+		},
+		"react-popper": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+			"integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+			"requires": {
+				"react-fast-compare": "^3.0.1",
+				"warning": "^4.0.2"
 			}
 		},
 		"react-proxy": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -81,12 +81,14 @@
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
+    "@popperjs/core": "^2.9.1",
     "@puppet/sass-variables": "^1.4.3",
     "classnames": "^2.2.6",
     "core-js": "^3.6.5",
     "hoist-non-react-statics": "^3.3.1",
     "prop-types": "^15.7.2",
     "react-modal": "^3.11.2",
+    "react-popper": "^2.2.5",
     "react-transition-group": "^4.4.1",
     "regenerator-runtime": "^0.13.7",
     "scroll-into-view-if-needed": "^2.2.25"

--- a/packages/react-components/source/index.js
+++ b/packages/react-components/source/index.js
@@ -11,9 +11,9 @@ import ButtonSelect from './react/library/button-select';
 import Card from './react/library/card';
 import Checkbox from './react/library/checkbox';
 import Code from './react/library/code';
-import Copy from './react/library/copy';
 import ConfirmationModal from './react/library/confirmation-modal';
 import Content from './react/library/content';
+import Copy from './react/library/copy';
 import Drawer from './react/library/drawer';
 import Filters from './react/library/filters';
 import Form from './react/library/form';
@@ -27,8 +27,8 @@ import Modal from './react/library/modal';
 import Popover from './react/library/popover';
 import RadioButton from './react/library/radiobutton';
 import Select from './react/library/select';
-import Sidebar from './react/library/sidebar';
 import SidePanel from './react/library/sidepanel';
+import Sidebar from './react/library/sidebar';
 import Switch from './react/library/switch';
 import Table from './react/library/table';
 import Tabs from './react/library/tabs';
@@ -36,6 +36,7 @@ import Tag from './react/library/tag';
 import Text from './react/library/text';
 import Toolbar from './react/library/toolbar';
 import TooltipHoverArea from './react/library/tooltips/TooltipHoverArea';
+import Overlay from './react/library/overlay';
 
 export {
   ActionSelect,
@@ -61,11 +62,12 @@ export {
   Loading,
   Logo,
   Modal,
+  Overlay,
   Popover,
   RadioButton,
   Select,
-  Sidebar,
   SidePanel,
+  Sidebar,
   Switch,
   Table,
   Tabs,

--- a/packages/react-components/source/react/helpers/customPropTypes.js
+++ b/packages/react-components/source/react/helpers/customPropTypes.js
@@ -20,6 +20,11 @@ export const anchorOrientation = PropTypes.oneOf([
   'bottom left',
 ]);
 
+export const reactRef = PropTypes.oneOfType([
+  PropTypes.func,
+  PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+]);
+
 const extendedErrorShape = {
   message: PropTypes.string.isRequired,
   sensitivity: PropTypes.number,

--- a/packages/react-components/source/react/helpers/useMergeRef.js
+++ b/packages/react-components/source/react/helpers/useMergeRef.js
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+
+const refToFn = ref => {
+  if (!ref || typeof ref === 'function') {
+    return ref;
+  }
+  return v => {
+    // eslint-disable-next-line no-param-reassign
+    ref.current = v;
+  };
+};
+
+const useMergeRef = (ref1, ref2) => {
+  return useMemo(() => {
+    const refFunc1 = refToFn(ref1);
+    const refFunc2 = refToFn(ref2);
+    return val => {
+      if (refFunc1) {
+        refFunc1(val);
+      }
+      if (refFunc2) {
+        refFunc2(val);
+      }
+    };
+  }, [ref1, ref2]);
+};
+
+export default useMergeRef;

--- a/packages/react-components/source/react/library/overlay/Overlay.js
+++ b/packages/react-components/source/react/library/overlay/Overlay.js
@@ -1,0 +1,139 @@
+import React, { forwardRef, useMemo, useState } from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import { usePopper } from 'react-popper';
+import useMergeRef from '../../helpers/useMergeRef';
+import { reactRef } from '../../helpers/customPropTypes';
+
+const propTypes = {
+  /** Optional (default outer). How to align the overlay in relation to the target element */
+  align: PropTypes.oneOf(['inner', 'outer', 'center']),
+  /** Content to be rendered inside the overlay */
+  children: PropTypes.node.isRequired,
+  /** Optional. React ref for the DOM element where the overlay should be mounted. If not defined the overlay is mounted in the same DOM element where it's declared. */
+  container: reactRef,
+  /** Optional. Override for the overlay offset (https://popper.js.org/docs/v2/modifiers/offset/). If declared, the align prop will be ignored. */
+  offset: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.number),
+  ]),
+  /** Optional (default bottom). Where to position the overlay in relation to the target element. */
+  position: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  /** Optional (default false). Whether or not the overlay should be rendered. */
+  show: PropTypes.bool,
+  /** React ref for the DOM element that should be used to position the overlay. */
+  target: reactRef.isRequired,
+};
+
+const defaultProps = {
+  align: 'outer',
+  container: null,
+  offset: null,
+  position: 'bottom',
+  show: false,
+};
+
+const innerAlignment = (position, { popper }) => {
+  switch (position) {
+    case 'top':
+    case 'bottom':
+      return [0, -popper.height];
+    case 'right':
+    case 'left':
+      return [0, -popper.width];
+    default:
+      return [];
+  }
+};
+
+const centerAlignment = (position, { popper }) => {
+  switch (position) {
+    case 'top':
+    case 'bottom':
+      return [0, -popper.height / 2];
+    case 'right':
+    case 'left':
+      return [0, -popper.width / 2];
+    default:
+      return [];
+  }
+};
+
+const overlayOffset = (align, position) => popperValues => {
+  switch (align) {
+    case 'inner':
+      return innerAlignment(position, popperValues);
+    case 'center':
+      return centerAlignment(position, popperValues);
+    default:
+      return [];
+  }
+};
+
+const resolveRef = ref => {
+  if (!ref || !ref.current) {
+    return null;
+  }
+
+  return ref.current.nodeType ? ref.current : null;
+};
+
+const withOffset = offset => ({
+  name: 'offset',
+  options: { offset },
+});
+
+const Overlay = forwardRef((props, fRef) => {
+  const {
+    align,
+    children,
+    container,
+    offset,
+    position,
+    show,
+    target,
+    ...rest
+  } = props;
+
+  const targetNode = resolveRef(target);
+  const [overlayNode, setOverlayNode] = useState(null);
+  const mergedRef = useMergeRef(setOverlayNode, fRef);
+  const offsetFn = useMemo(() => overlayOffset(align, position), [
+    align,
+    position,
+  ]);
+  const { styles, attributes } = usePopper(targetNode, overlayNode, {
+    placement: position,
+    modifiers: [withOffset(offset || offsetFn)],
+  });
+
+  if (!show) {
+    return null;
+  }
+
+  const containerNode = resolveRef(container);
+
+  if (container && containerNode === null) {
+    return null;
+  }
+
+  if (targetNode === null) {
+    return null;
+  }
+
+  const renderContent = (
+    <div ref={mergedRef} style={styles.popper} {...rest} {...attributes.popper}>
+      {children}
+    </div>
+  );
+
+  return containerNode
+    ? ReactDOM.createPortal(renderContent, containerNode)
+    : renderContent;
+});
+
+Overlay.propTypes = propTypes;
+
+Overlay.defaultProps = defaultProps;
+
+export default Overlay;

--- a/packages/react-components/source/react/library/overlay/Overlay.md
+++ b/packages/react-components/source/react/library/overlay/Overlay.md
@@ -1,0 +1,118 @@
+## Overview
+
+Overlays allow you to place any content on top of the existing view. The overlay placed in relation to a target element, and is positioned based on the `align` and `position` properties.
+
+## Visibility and positioning
+
+```jsx
+import Button from '../button';
+
+const parentStyle = {
+  padding: '20px',
+  border: '1px solid black',
+  maxWidth: '500px',
+  marginTop: '20px',
+};
+const targetStyle = {
+  padding: '15px',
+  border: '1px solid black',
+};
+const overlayStyle = {
+  backgroundColor: '#222629',
+  color: 'white',
+  padding: '10px',
+};
+
+const selectNext = (arr, selectFn, current) => () => {
+  selectFn((current + 1) % arr.length);
+};
+
+const positions = ['top', 'right', 'bottom', 'left'];
+const alignments = ['outer', 'center', 'inner'];
+
+const [position, setPosition] = React.useState(0);
+const [align, setAlign] = React.useState(0);
+const [visible, setVisible] = React.useState(false);
+
+const targetRef = React.useRef(null);
+
+<div>
+  <Button onClick={selectNext(positions, setPosition, position)}>
+    Toggle position
+  </Button>
+  <Button onClick={selectNext(alignments, setAlign, align)}>
+    Toggle alignment
+  </Button>
+  <Button onClick={() => setVisible(!visible)}>
+    {visible ? 'Hide' : 'Show'}
+  </Button>
+
+  <div style={parentStyle}>
+    <p>Position: {positions[position]}</p>
+    <p>Align: {alignments[align]}</p>
+    <p ref={targetRef} style={targetStyle}>
+      Target container
+    </p>
+  </div>
+
+  <Overlay
+    target={targetRef}
+    position={positions[position]}
+    align={alignments[align]}
+    show={visible}
+  >
+    <div style={overlayStyle}>Overlay</div>
+  </Overlay>
+</div>;
+```
+
+## Uses
+
+### Confirm delete
+
+```jsx
+import Button from '../button';
+import Table from '../table';
+
+const [isVisible, setIsVisible] = React.useState(false);
+const targetRef = React.useRef(null);
+
+const renderActions = () => (
+  <Button
+    ref={targetRef}
+    type="transparent"
+    icon="trash"
+    disabled={isVisible}
+    onClick={() => setIsVisible(true)}
+  />
+);
+const columns = [
+  { label: 'Name', dataKey: 'name' },
+  { label: 'Description', dataKey: 'description' },
+  {
+    label: 'Actions',
+    dataKey: 'actions',
+    cellRenderer: renderActions,
+    style: { textAlign: 'center' },
+  },
+];
+
+const rows = [
+  { id: 1, name: 'Name 1', description: 'First name', actions: '' },
+];
+
+<div>
+  <Table data={rows} columns={columns} />
+
+  <Overlay target={targetRef} show={isVisible} position="right" align="inner">
+    <div>
+      <Button type="danger" onClick={() => setIsVisible(false)}>
+        Delete
+      </Button>
+      <Button type="tertiary" onClick={() => setIsVisible(false)}>
+        Cancel
+      </Button>
+    </div>
+  </Overlay>
+</div>;
+```

--- a/packages/react-components/source/react/library/overlay/index.js
+++ b/packages/react-components/source/react/library/overlay/index.js
@@ -1,0 +1,3 @@
+import Overlay from './Overlay';
+
+export default Overlay;


### PR DESCRIPTION
### Overview

Adds `Overlay` component that can place any content on top of the existing view. The component is built using [PopperJS](https://popper.js.org/docs/v2/).

The overlay is positioned relative to a target element, and the final position can be adjusted using the `align` and `position` properties. The position of the overlay can also be overwritten by passing and offset function or tuple (https://popper.js.org/docs/v2/modifiers/offset/). By default, the overlay will be rendered within the same DOM element where it is defined, but if a container ref is provided, the overlay can be injected into any DOM element.

### Examples

#### Positioning

https://user-images.githubusercontent.com/25378324/113339062-f2062b00-92f7-11eb-9d1b-6b62710bbf18.mov

#### Confirm delete

https://user-images.githubusercontent.com/25378324/113339056-ee72a400-92f7-11eb-90bb-8bfa91f63d74.mov
