### PR TITLE
Fix hover state for Sidebar.Footer link

### DIFF
--- a/packages/react-components/source/react/library/sidebar/SidebarFooter.js
+++ b/packages/react-components/source/react/library/sidebar/SidebarFooter.js
@@ -47,6 +47,7 @@ const SidebarFooter = ({
   const Component = as;
   let meta;
   let signout;
+  const clickable = Boolean(rest.onClick) || as !== defaultProps.as;
 
   if (!minimized) {
     meta = (
@@ -79,7 +80,7 @@ const SidebarFooter = ({
       <Component
         className={classnames('rc-sidebar-footer-button-user', {
           'rc-sidebar-footer-button-minimized': minimized,
-          'rc-sidebar-footer-clickable': rest.onClick,
+          'rc-sidebar-footer-clickable': clickable,
         })}
         {...rest}
       >

--- a/packages/react-components/source/scss/library/components/_sidebar.scss
+++ b/packages/react-components/source/scss/library/components/_sidebar.scss
@@ -263,6 +263,7 @@ $puppet-sidebar-footer-signout-left-margin: 3px !default;
     outline: none;
     padding: 0 0 0 $puppet-sidebar-padding;
     text-align: left;
+    text-decoration: none;
 
     &.rc-sidebar-footer-clickable {
       cursor: pointer;


### PR DESCRIPTION
The CSS class `rc-sidebar-footer-clickable` was only getting added when `Sidebar.Footer` was passed an `onClick` prop, which excluded other "clickable" uses like `<Sidebar.Footer as="a" href="/profile" />`. This PR assumes it is clickable when any non-default `as` prop is passed in, which would also cover uses of React Router.

Before:

<img width="1552" alt="Screen Shot 2021-04-14 at 9 13 43 AM" src="https://user-images.githubusercontent.com/175123/114743849-eb1ce680-9d01-11eb-89f5-5e7c70093fd5.png">

After:

<img width="1552" alt="Screen Shot 2021-04-14 at 9 14 42 AM" src="https://user-images.githubusercontent.com/175123/114743863-ee17d700-9d01-11eb-8240-3fe38999054b.png">
