### PR TITLE
(maint) Allow breadcrumb sections to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# react-component 5.27.4 (unreleased)
+
+- [Breadcrumb.Section] Add `disabled` prop to disable Breadcrumb section link (by [@mardotio](https://github.com/mardotio)) in [#414](https://github.com/puppetlabs/design-system/pull/414)
+
 # react-components 5.27.3 (2021-04-23)
 
 - [Form] Add `submitDisabled` prop to Form component to disable submit button (by [@cathal41](https://github.com/cathal41) in [#406](https://github.com/puppetlabs/design-system/pull/406))

--- a/packages/react-components/source/react/library/breadcrumb/BreadcrumbSection.js
+++ b/packages/react-components/source/react/library/breadcrumb/BreadcrumbSection.js
@@ -9,14 +9,21 @@ const propTypes = {
   children: PropTypes.node,
   /** Set internally--Is the breacrumb the leaf element? */
   active: PropTypes.bool,
+  /** Whether or not the breadcrumb should be rendered as a link or plain text */
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
   children: undefined,
   active: false,
+  disabled: false,
 };
 
-const BreadcrumbSection = ({ children, active, ...props }) => {
+const BreadcrumbSection = ({ children, active, disabled, ...props }) => {
+  const chevron = active ? null : (
+    <Icon type="chevron-right" aria-hidden="true" />
+  );
+
   let crumb = (
     <li>
       <Hyperlink
@@ -28,11 +35,11 @@ const BreadcrumbSection = ({ children, active, ...props }) => {
       >
         {children}
       </Hyperlink>
-      <Icon type="chevron-right" aria-hidden="true" />
+      {chevron}
     </li>
   );
 
-  if (active) {
+  if (active || disabled) {
     crumb = (
       <li>
         <Text
@@ -43,6 +50,7 @@ const BreadcrumbSection = ({ children, active, ...props }) => {
         >
           {children}
         </Text>
+        {chevron}
       </li>
     );
   }


### PR DESCRIPTION
### Current Behavior
- Only the last section of a breadcrumb can be disabled

### New Behavior
- Any breadcrumb section can be manually disabled using the `disabled` prop

<img width="925" alt="Screen Shot 2021-04-26 at 5 20 52 PM" src="https://user-images.githubusercontent.com/25378324/116152602-2204dc00-a6b4-11eb-847f-ff3a31b71c68.png">