### PR TITLE
Add docs for customizing icon color

### DIFF
--- a/packages/react-components/source/react/library/icon/Icon.md
+++ b/packages/react-components/source/react/library/icon/Icon.md
@@ -94,6 +94,14 @@ const Renderer = () => {
 <Renderer />;
 ```
 
+## Customize icon color
+
+If you need a different color, you can customize it with CSS, targeting the `fill` property. The default color is defined in [_icons.scss](https://github.com/puppetlabs/design-system/blob/development/packages/react-components/source/scss/library/components/_icons.scss). You should be able to do something like `.your-icon { fill: $puppet-purple; }` with Sass.
+
+```jsx
+<Icon type="activity" style={{ fill: '#a263ff' }} />
+```
+
 ## Custom SVG use
 
 To use a custom SVG not included in the chart above, separately specify both the `path` attribute to the `svg` prop and the `viewBox` attribute to the `viewBox` prop.


### PR DESCRIPTION
This adds a section "Customize icon color" to https://puppet.style/#/React%20Components/Icon

<img width="486" alt="Screen Shot 2021-05-03 at 1 05 28 PM" src="https://user-images.githubusercontent.com/175123/116927220-3c890900-ac10-11eb-9061-bb2a8cd29a90.png">
