### PR TITLE
Add Alerts component

### DIFF
--- a/packages/react-components/source/index.js
+++ b/packages/react-components/source/index.js
@@ -3,6 +3,7 @@ import 'regenerator-runtime/runtime';
 
 import ActionSelect from './react/library/action-select';
 import Alert from './react/library/alert';
+import Alerts from './react/library/alerts';
 import Avatar from './react/library/avatar';
 import Badge from './react/library/badge';
 import Breadcrumb from './react/library/breadcrumb';
@@ -41,6 +42,7 @@ import Overlay from './react/library/overlay';
 export {
   ActionSelect,
   Alert,
+  Alerts,
   Avatar,
   Badge,
   Breadcrumb,

--- a/packages/react-components/source/react/library/alerts/Alerts.js
+++ b/packages/react-components/source/react/library/alerts/Alerts.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  /** Main content where a collection of Alert components can be passed */
+  children: PropTypes.node,
+};
+const defaultProps = {
+  children: '',
+};
+
+/** Alerts is a container for floating "growl" notifications. */
+const Alerts = ({ children }) => <div className="rc-alerts">{children}</div>;
+
+Alerts.propTypes = propTypes;
+Alerts.defaultProps = defaultProps;
+
+export default Alerts;

--- a/packages/react-components/source/react/library/alerts/Alerts.md
+++ b/packages/react-components/source/react/library/alerts/Alerts.md
@@ -1,0 +1,65 @@
+## Overview
+
+The Alerts component is a container that displays a collection of floating ("growl") Alert components fixed to the upper-right of the screen.
+
+### Basic use
+
+Simply pass a collection of Alert components to be wrapped by Alerts.
+
+```jsx
+import Alert from '../alert';
+import Button from '../button';
+
+const [showAlerts, setShowAlerts] = React.useState(false);
+
+<>
+  <Button
+    onClick={() => {
+      setShowAlerts(true);
+      setTimeout(() => setShowAlerts(false), 5000);
+    }}
+  >
+    Show alert and hide after 5 seconds
+  </Button>
+  {showAlerts && (
+    <Alerts>
+      <Alert type="danger">Heads up! Something went wrong.</Alert>
+    </Alerts>
+  )}
+</>;
+```
+
+### Closeable alerts
+
+See Alert documentation for options available in that component like `closeable` since Alerts is a simple wrapper for positioning.
+
+```jsx
+import Alert from '../alert';
+import Button from '../button';
+
+const [alerts, setAlerts] = React.useState([]);
+const initialAlerts = [
+  { id: 'first', message: 'Heads up! Something went wrong.' },
+  { id: 'second', message: 'And another thing seems to have gone wrong.' },
+];
+
+<>
+  <Button onClick={() => setAlerts(initialAlerts)}>
+    Show closeable alerts
+  </Button>
+  {alerts.length > 0 && (
+    <Alerts>
+      {alerts.map((alert) => (
+        <Alert
+          key={alert.id}
+          type="danger"
+          closeable
+          onClose={() => setAlerts(alerts.filter(a => a.id !== alert.id))}
+        >
+          {alert.message}
+        </Alert>
+      ))}
+    </Alerts>
+  )}
+</>;
+```

--- a/packages/react-components/source/react/library/alerts/index.js
+++ b/packages/react-components/source/react/library/alerts/index.js
@@ -1,0 +1,3 @@
+import Alerts from './Alerts';
+
+export default Alerts;

--- a/packages/react-components/source/scss/library/components/_alerts.scss
+++ b/packages/react-components/source/scss/library/components/_alerts.scss
@@ -164,3 +164,18 @@ $colors: (
 .rc-error-alert-cause {
   font-family: $puppet-type-font-family-monospace;
 }
+
+// Alerts container for floating "growl" alerts
+.rc-alerts {
+  height: auto;
+  margin: $puppet-common-spacing-base * 4;
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: $puppet-common-spacing-base * 112;
+  z-index: 1000;
+
+  .rc-alert {
+    margin-bottom: $puppet-common-spacing-base * 3;
+  }
+}


### PR DESCRIPTION
Resolves [PDS-585](https://tickets.puppetlabs.com/browse/PDS-585)

- Add `Alerts` component, a container component to which you can pass a collection of `Alert` components to display them as floating "growl" notifications.
- Add documentation with a couple examples.

<img width="1363" alt="Screen Shot 2021-05-05 at 9 04 37 AM" src="https://user-images.githubusercontent.com/175123/117173019-34041000-ad81-11eb-9714-8448198fd469.png">
