### PR TITLE
Add option groups to Select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# react-component 5.28.0 (2021-05-06)
+# react-components 5.29.0 (2021-06-01)
+
+- [Select] Add support for option groups to the Select component and fix keyboard handling of disabled options (by [@caseywilliams](https://github.com/caseywilliams)) in [#431](https://github.com/puppetlabs/design-system/pull/431)
+
+# react-components 5.28.0 (2021-05-06)
 
 - [Alerts] Add Alerts component (by [@vine77](https://github.com/vine77) in [#416](https://github.com/puppetlabs/design-system/pull/416))
 - [Breadcrumb] Add `disabled` prop to Breadcrumb.Section (by [@mardotio](https://github.com/mardotio)) in [#414](https://github.com/puppetlabs/design-system/pull/414)

--- a/packages/data-grid/src/__test__/__snapshots__/quickFitler.test.jsx.snap
+++ b/packages/data-grid/src/__test__/__snapshots__/quickFitler.test.jsx.snap
@@ -252,6 +252,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
                     onMouseEnter={[Function]}
                     selected={false}
                     svg={null}
+                    type="option"
                   >
                     <li
                       aria-selected={false}
@@ -304,6 +305,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
                     onMouseEnter={[Function]}
                     selected={false}
                     svg={null}
+                    type="option"
                   >
                     <li
                       aria-selected={false}
@@ -356,6 +358,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
                     onMouseEnter={[Function]}
                     selected={false}
                     svg={null}
+                    type="option"
                   >
                     <li
                       aria-selected={false}
@@ -600,6 +603,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
                     onMouseEnter={[Function]}
                     selected={false}
                     svg={null}
+                    type="option"
                   >
                     <li
                       aria-selected={false}
@@ -652,6 +656,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
                     onMouseEnter={[Function]}
                     selected={false}
                     svg={null}
+                    type="option"
                   >
                     <li
                       aria-selected={false}
@@ -704,6 +709,7 @@ exports[`Snapshot test Check component matches previous HTML snapshot 1`] = `
                     onMouseEnter={[Function]}
                     selected={false}
                     svg={null}
+                    type="option"
                   >
                     <li
                       aria-selected={false}

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.28.0",
+  "version": "5.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.28.0",
+  "version": "5.29.0",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/react/helpers/customPropTypes.js
+++ b/packages/react-components/source/react/helpers/customPropTypes.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import Icon from '../library/icon';
 
 /**
  * Design system available element elevations
@@ -80,4 +81,17 @@ export const deprecated = message => typeChecker => {
 
     return typeChecker(props, key, componentName, location, propFullName);
   };
+};
+
+export const optionMenuItemShape = {
+  /** Value of the option */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** The label to show */
+  label: PropTypes.node.isRequired,
+  /** Optional icon associated with this option */
+  icon: PropTypes.oneOf(Icon.AVAILABLE_ICONS),
+  /** Optional custom icon associated with this option */
+  svg: PropTypes.element,
+  /** Whether this option is disabled */
+  disabled: PropTypes.bool,
 };

--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { isNil, focus, cancelEvent } from '../../helpers/statics';
+import { optionMenuItemShape } from '../../helpers/customPropTypes';
 
 import {
   UP_KEY_CODE,
@@ -15,7 +16,6 @@ import {
 } from '../../constants';
 
 import OptionMenuListItem from './OptionMenuListItem';
-import Icon from '../../library/icon';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -23,13 +23,13 @@ const propTypes = {
   autocomplete: PropTypes.bool,
   showCancel: PropTypes.bool,
   options: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-        .isRequired,
-      label: PropTypes.node.isRequired,
-      icon: PropTypes.oneOf(Icon.AVAILABLE_ICONS),
-      disabled: PropTypes.bool,
-    }),
+    PropTypes.oneOfType([
+      PropTypes.shape(optionMenuItemShape),
+      PropTypes.shape({
+        ...optionMenuItemShape,
+        value: PropTypes.arrayOf(PropTypes.shape(optionMenuItemShape)),
+      }),
+    ]),
   ),
   selected: PropTypes.oneOfType([
     PropTypes.string,
@@ -72,10 +72,16 @@ const defaultProps = {
 
 const getOptionId = (id, value) => `${id}-${value}`;
 
+const getFocusableOptions = options =>
+  options.map(opt => (Array.isArray(opt.value) ? opt.value : opt)).flat();
+
 const getFocusedId = (focusedIndex, id, options) =>
-  isNil(focusedIndex) || focusedIndex >= options.length
+  typeof focusedIndex !== 'number' || focusedIndex >= options.length
     ? undefined
-    : getOptionId(id, options[focusedIndex].value);
+    : getOptionId(
+        id,
+        getFocusableOptions(options)[Math.max(focusedIndex, 0)].value,
+      );
 
 const getSelectionSet = selection =>
   new Set(
@@ -134,7 +140,11 @@ class OptionMenuList extends Component {
   }
 
   onMouseEnterItem(focusedIndex) {
-    this.focusItem(focusedIndex);
+    if (typeof focusedIndex === 'number') {
+      this.focusItem(focusedIndex);
+    } else {
+      this.setState({ focusedIndex: null });
+    }
   }
 
   onCancel(e) {
@@ -161,7 +171,9 @@ class OptionMenuList extends Component {
     if (isNil(focusedIndex)) {
       this.focusFirst();
     } else {
-      this.focusItem(Math.min(options.length - 1, focusedIndex + 1));
+      this.focusItem(
+        Math.min(getFocusableOptions(options).length - 1, focusedIndex + 1),
+      );
     }
   }
 
@@ -192,7 +204,7 @@ class OptionMenuList extends Component {
       }
       case SPACE_KEY_CODE:
       case ENTER_KEY_CODE: {
-        const focused = options[focusedIndex];
+        const focused = getFocusableOptions(options)[focusedIndex];
         if (focused && !focused.disabled) {
           this.selectFocusedItem();
           onClickItem();
@@ -251,7 +263,7 @@ class OptionMenuList extends Component {
   focusLast() {
     const { options } = this.props;
 
-    this.focusItem(options.length - 1);
+    this.focusItem(getFocusableOptions(options).length - 1);
   }
 
   focusItem(focusedIndex) {
@@ -296,7 +308,7 @@ class OptionMenuList extends Component {
     const { options } = this.props;
 
     if (!isNil(focusedIndex)) {
-      const { value } = options[focusedIndex];
+      const { value } = getFocusableOptions(options)[focusedIndex];
 
       this.select(value);
     }
@@ -304,17 +316,6 @@ class OptionMenuList extends Component {
 
   /* eslint-disable jsx-a11y/click-events-have-key-events */
   render() {
-    const {
-      onClickItem,
-      onMouseEnterItem,
-      onCancel,
-      onKeyDown,
-      onKeyDownInAction,
-      onFocus,
-      onMenuBlur,
-      onActionBlur,
-    } = this;
-    const { focusedIndex } = this.state;
     const {
       id,
       options,
@@ -329,7 +330,6 @@ class OptionMenuList extends Component {
       className,
       style,
       onBlur,
-      focusedIndex: focussed,
       onFocusItem,
       footer,
       onClickItem: onClick,
@@ -340,8 +340,95 @@ class OptionMenuList extends Component {
       return null;
     }
 
+    const {
+      onClickItem,
+      onMouseEnterItem,
+      onCancel,
+      onKeyDown,
+      onKeyDownInAction,
+      onFocus,
+      onMenuBlur,
+      onActionBlur,
+    } = this;
+
     const selectionSet = getSelectionSet(selected);
-    const focusedId = getFocusedId(focusedIndex, id, options);
+
+    delete rest.focusedIndex;
+    const { focusedIndex } = this.state;
+    const focusedId = getFocusedId(
+      focusedIndex,
+      id,
+      getFocusableOptions(options),
+    );
+
+    const renderListItems = (items, offset = 0) => {
+      const list = [];
+
+      items.forEach(item => {
+        if (Array.isArray(item.value)) {
+          const groupId = `group-${item.value
+            .map(child => child.value)
+            .join('-')}`;
+          const labelId = `${groupId}-label`;
+
+          list.push(
+            <ul
+              role="group"
+              aria-labelledby={labelId}
+              className="rc-menu-list-group"
+              id={groupId}
+              key={groupId}
+            >
+              {item.label && (
+                <OptionMenuListItem
+                  type="heading"
+                  disabled={item.disabled}
+                  id={labelId}
+                  key={labelId}
+                  onMouseEnter={() => onMouseEnterItem(null)}
+                >
+                  {item.label}
+                </OptionMenuListItem>
+              )}
+              {renderListItems(
+                item.value.map(child =>
+                  Object.assign(child, {
+                    disabled: item.disabled || child.disabled,
+                  }),
+                ),
+                list.length + offset,
+              )}
+            </ul>,
+          );
+          // eslint-disable-next-line no-param-reassign
+          offset += item.value.length - 1;
+        } else {
+          const index = list.length + offset;
+          list.push(
+            <OptionMenuListItem
+              id={getOptionId(id, item.value)}
+              key={item.value}
+              focused={index === focusedIndex}
+              selected={selectionSet.has(item.value)}
+              icon={item.icon}
+              svg={item.svg}
+              disabled={item.disabled}
+              onClick={() =>
+                item.disabled ? undefined : onClickItem(item.value)
+              }
+              onMouseEnter={() => onMouseEnterItem(index)}
+              ref={option => {
+                this.optionRefs[index] = option;
+              }}
+            >
+              {item.label}
+            </OptionMenuListItem>,
+          );
+        }
+      });
+
+      return list;
+    };
 
     const list = (
       <ul
@@ -359,24 +446,7 @@ class OptionMenuList extends Component {
         }}
         {...rest}
       >
-        {options.map(({ value, label, icon, svg, disabled }, index) => (
-          <OptionMenuListItem
-            id={getOptionId(id, value)}
-            key={value}
-            focused={index === focusedIndex}
-            selected={selectionSet.has(value)}
-            icon={icon}
-            svg={svg}
-            disabled={disabled}
-            onClick={disabled ? undefined : () => onClickItem(value)}
-            onMouseEnter={() => onMouseEnterItem(index)}
-            ref={option => {
-              this.optionRefs[index] = option;
-            }}
-          >
-            {label}
-          </OptionMenuListItem>
-        ))}
+        {renderListItems(options)}
       </ul>
     );
 

--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuList.js
@@ -78,7 +78,9 @@ const getFocusedId = (focusedIndex, id, options) =>
     : getOptionId(id, options[focusedIndex].value);
 
 const getSelectionSet = selection =>
-  new Set(Array.isArray(selection) ? selection : [selection]);
+  new Set(
+    (Array.isArray(selection) ? selection : [selection]).filter(el => !!el),
+  );
 
 class OptionMenuList extends Component {
   constructor(props) {
@@ -164,7 +166,8 @@ class OptionMenuList extends Component {
   }
 
   onKeyDown(e) {
-    const { onEscape, onClickItem } = this.props;
+    const { onEscape, onClickItem, options } = this.props;
+    const { focusedIndex } = this.state;
 
     switch (e.keyCode) {
       case UP_KEY_CODE: {
@@ -189,8 +192,11 @@ class OptionMenuList extends Component {
       }
       case SPACE_KEY_CODE:
       case ENTER_KEY_CODE: {
-        this.selectFocusedItem();
-        onClickItem();
+        const focused = options[focusedIndex];
+        if (focused && !focused.disabled) {
+          this.selectFocusedItem();
+          onClickItem();
+        }
         cancelEvent(e);
         break;
       }

--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuListItem.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuListItem.js
@@ -13,7 +13,7 @@ const propTypes = {
   icon: PropTypes.oneOf(Icon.AVAILABLE_ICONS),
   /** Or pass in your own svg... */
   svg: PropTypes.element,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   onMouseEnter: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
 };
@@ -22,6 +22,7 @@ const defaultProps = {
   icon: null,
   svg: null,
   disabled: false,
+  onClick: null,
 };
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */

--- a/packages/react-components/source/react/internal/option-menu-list/OptionMenuListItem.js
+++ b/packages/react-components/source/react/internal/option-menu-list/OptionMenuListItem.js
@@ -4,25 +4,35 @@ import PropTypes from 'prop-types';
 
 import Icon from '../../library/icon';
 
+const types = {
+  OPTION: 'option',
+  HEADING: 'heading',
+};
+
 const propTypes = {
   id: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
-  focused: PropTypes.bool.isRequired,
-  selected: PropTypes.bool.isRequired,
+  focused: PropTypes.bool,
+  selected: PropTypes.bool,
   /** Optional: choose an icon */
   icon: PropTypes.oneOf(Icon.AVAILABLE_ICONS),
   /** Or pass in your own svg... */
   svg: PropTypes.element,
   onClick: PropTypes.func,
-  onMouseEnter: PropTypes.func.isRequired,
+  onMouseEnter: PropTypes.func,
   disabled: PropTypes.bool,
+  type: PropTypes.oneOf(Object.values(types)),
 };
 
 const defaultProps = {
   icon: null,
   svg: null,
+  focused: false,
   disabled: false,
+  selected: false,
   onClick: null,
+  onMouseEnter: null,
+  type: types.OPTION,
 };
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -38,34 +48,52 @@ const OptionMenuListItem = forwardRef(
       onClick,
       onMouseEnter,
       disabled,
+      type,
     },
     ref,
-  ) => (
-    <li
-      role="option"
-      id={id}
-      className={classNames('rc-menu-list-item', {
-        'rc-menu-list-item-focused': focused,
-        'rc-menu-list-item-selected': selected,
-        'rc-menu-list-item-disabled': disabled,
-      })}
-      aria-selected={selected}
-      onClick={onClick}
-      onMouseEnter={onMouseEnter}
-      ref={ref}
-    >
-      {icon && <Icon className="rc-menu-list-item-icon" type={icon} />}
-      {svg && !icon && <Icon className="rc-menu-list-item-icon" svg={svg} />}
-      <span className="rc-menu-list-item-content">{children}</span>
-      {selected && (
-        <Icon
-          className="rc-menu-list-item-checkmark"
-          type="check"
-          size="small"
-        />
-      )}
-    </li>
-  ),
+  ) => {
+    const isHeading = type === types.HEADING;
+    const itemProps = {
+      id,
+      ref,
+      onMouseEnter,
+      onClick,
+      role: isHeading ? 'presentation' : 'option',
+    };
+
+    if (!isHeading) {
+      itemProps['aria-selected'] = selected;
+    }
+
+    return (
+      <li
+        {...itemProps}
+        className={classNames(
+          'rc-menu-list-item',
+          {
+            'rc-menu-list-item-disabled': disabled,
+          },
+          isHeading
+            ? 'rc-menu-list-group-heading'
+            : {
+                'rc-menu-list-item-focused': focused,
+                'rc-menu-list-item-selected': selected,
+              },
+        )}
+      >
+        {icon && <Icon className="rc-menu-list-item-icon" type={icon} />}
+        {svg && !icon && <Icon className="rc-menu-list-item-icon" svg={svg} />}
+        <span className="rc-menu-list-item-content">{children}</span>
+        {!isHeading && selected && (
+          <Icon
+            className="rc-menu-list-item-checkmark"
+            type="check"
+            size="small"
+          />
+        )}
+      </li>
+    );
+  },
 );
 /* eslint-enable */
 

--- a/packages/react-components/source/react/library/select/Select.js
+++ b/packages/react-components/source/react/library/select/Select.js
@@ -2,8 +2,10 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import OptionMenuList from '../../internal/option-menu-list';
-import { anchorOrientation } from '../../helpers/customPropTypes';
-import Icon from '../icon';
+import {
+  anchorOrientation,
+  optionMenuItemShape,
+} from '../../helpers/customPropTypes';
 import Input from '../input';
 import SelectTarget from './SelectTarget';
 import { getDropdownPosition, focus, cancelEvent } from '../../helpers/statics';
@@ -23,16 +25,13 @@ const propTypes = {
   name: PropTypes.string.isRequired,
   /** An Array of select options */
   options: PropTypes.arrayOf(
-    PropTypes.shape({
-      /** Select option value */
-      value: PropTypes.string.isRequired,
-      /** Select option label */
-      label: PropTypes.string.isRequired,
-      /** Optional icon associated with this option */
-      icon: PropTypes.oneOf(Icon.AVAILABLE_ICONS),
-      /** Optional custom icon associated with this option */
-      svg: PropTypes.element,
-    }),
+    PropTypes.oneOfType([
+      PropTypes.shape(optionMenuItemShape),
+      PropTypes.shape({
+        ...optionMenuItemShape,
+        value: PropTypes.arrayOf(PropTypes.shape(optionMenuItemShape)),
+      }),
+    ]),
   ),
   /** Currently selected value or values */
   value: PropTypes.oneOfType([
@@ -283,37 +282,41 @@ class Select extends Component {
   }
 
   getButtonLabel() {
-    const { type, options, value, placeholder } = this.props;
+    const { type, value, placeholder } = this.props;
     if (!value || value.length === 0) {
       return placeholder;
     }
 
     if (type === MULTISELECT) {
-      const selectedOptions = options
+      const selectedOptions = this.getOptions()
         .filter(option => value.includes(option.value))
         .map(option => option.selectedLabel || option.label);
 
       return selectedOptions.join(', ');
     }
 
-    const selectedOption = options.find(option => option.value === value);
+    const selectedOption = this.getOptions().find(
+      option => option.value === value,
+    );
 
     return selectedOption.label;
   }
 
   getOptions() {
     const { options, value, type, onFilter } = this.props;
-    let filteredOptions = options;
+    let opts = options
+      .map(opt => (Array.isArray(opt.value) ? opt.value : opt))
+      .flat();
 
     // If the ingesting app uses the onFilter event handler, it should provide the filtered options
     // Otherwise, let's filter the presumably static list here
     if (value && type === AUTOCOMPLETE && !onFilter) {
-      filteredOptions = options.filter(
+      opts = opts.filter(
         option => option.value.toLowerCase().indexOf(value.toLowerCase()) > -1,
       );
     }
 
-    return filteredOptions;
+    return opts;
   }
 
   closeAndFocusButton() {
@@ -356,22 +359,22 @@ class Select extends Component {
       getButtonLabel,
       onKeyDown,
       onFocusItem,
-      getOptions,
       open: onOpen,
     } = this;
     const { open, menuStyle, listValue, focusedIndex } = this.state;
     const {
-      name,
-      type,
-      disabled,
-      className,
-      style,
-      error,
-      value,
-      placeholder,
       applyImmediately,
-      required,
+      className,
+      disabled,
+      error,
       footer,
+      name,
+      options,
+      placeholder,
+      required,
+      style,
+      type,
+      value,
     } = this.props;
 
     let input;
@@ -457,7 +460,7 @@ class Select extends Component {
           multiple={type === MULTISELECT}
           autocomplete={type === AUTOCOMPLETE}
           showCancel={type === MULTISELECT && !applyImmediately}
-          options={getOptions()}
+          options={options}
           selected={listValue}
           focusedIndex={focusedIndex}
           aria-labelledby={`${name}-label`}

--- a/packages/react-components/source/react/library/select/Select.js
+++ b/packages/react-components/source/react/library/select/Select.js
@@ -130,8 +130,8 @@ class Select extends Component {
     this.getOptions = this.getOptions.bind(this);
   }
 
-  static getDerivedStateFromProps(props, state) {
-    if (isControlled(props) || !state.open) {
+  static getDerivedStateFromProps(props) {
+    if (isControlled(props)) {
       return {
         listValue: props.value,
       };

--- a/packages/react-components/source/react/library/select/Select.md
+++ b/packages/react-components/source/react/library/select/Select.md
@@ -81,6 +81,45 @@ const style = { margin: 10 };
 </div>;
 ```
 
+### Option groups
+
+To render an option group, provide an array of child options as the value for a regular option. Parent options should
+still have labels, and if a parent is disabled, all its child options will be disabled, too.
+
+```jsx
+const optionsWithGroups = [{
+  label: "Spices",
+  value: [
+    {label: "Cinnamon", value: "cinnamon"},
+    {label: "Coriander", value: "coriander"},
+    {label: "Cumin", value: "cumin"},
+  ]
+}, {
+  label: "Oil",
+  value: "oil"
+}, {
+  label: "Vinegar",
+  value: "vinegar"
+}, {
+  label: "Herbs",
+  disabled: true,
+  value: [
+    {label: "Parsley", value: "parsley"},
+    {label: "Sage", value: "sage"},
+    {label: "Rosemary", value: "rosemary"},
+  ]
+}];
+
+<Select
+  name="select-option-group-example"
+  options={optionsWithGroups}
+  value={state.value}
+  onChange={value => {
+    setState({value});
+  }}
+/>;
+```
+
 ### MultiSelect
 
 With `type` set to `multiselect`, the `Select` input will allow multiple values to be selected. In this mode, an "Apply" button will render below the options list. The newly selected values are not applied until the user activates this button. If the options chosen exceed the side of the input, the excess content will be replaced with an ellipsis. If the user presses escape, clicks the "Cancel" button, or clicks out of the open menu, their changes will be discarded.

--- a/packages/react-components/source/scss/library/components/_menu-list.scss
+++ b/packages/react-components/source/scss/library/components/_menu-list.scss
@@ -26,6 +26,11 @@
   }
 }
 
+.rc-menu-list-group {
+  margin: 0;
+  padding: 0;
+}
+
 .rc-menu-action-container {
   display: flex;
 }
@@ -72,7 +77,17 @@
   cursor: pointer;
   display: flex;
   list-style-type: none;
-  padding: 4px 8px;
+  padding: $puppet-common-spacing-base $puppet-common-spacing-base * 2;
+}
+
+.rc-menu-list-group {
+  .rc-menu-list-item {
+    padding-left: $puppet-common-spacing-base * 3;
+  }
+
+  .rc-menu-list-group-heading {
+    padding-left: $puppet-common-spacing-base * 2;
+  }
 }
 
 .rc-menu-list-item-inner {
@@ -97,6 +112,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.rc-menu-list-group-heading {
+  @include puppet-type-h6();
 }
 
 .rc-menu-list-item-checkmark {

--- a/packages/react-components/source/scss/library/components/_menu-list.scss
+++ b/packages/react-components/source/scss/library/components/_menu-list.scss
@@ -34,7 +34,8 @@
 
 .rc-menu-list-group:only-child,
 .rc-menu-list-group:last-child {
-  border-bottom: none;
+  border-bottom-style: none;
+  border-bottom-width: 0;
   margin: 0;
   padding: 0;
 }

--- a/packages/react-components/source/scss/library/components/_menu-list.scss
+++ b/packages/react-components/source/scss/library/components/_menu-list.scss
@@ -27,8 +27,22 @@
 }
 
 .rc-menu-list-group {
+  border-bottom: solid 1px $puppet-n300;
+  margin: 0 0 4px;
+  padding: 0 0 4px;
+}
+
+.rc-menu-list-group:only-child,
+.rc-menu-list-group:last-child {
+  border-bottom: none;
   margin: 0;
   padding: 0;
+}
+
+li + .rc-menu-list-group {
+  border-top: solid 1px $puppet-n300;
+  margin-top: 4px;
+  padding-top: 4px;
 }
 
 .rc-menu-action-container {

--- a/packages/react-components/test/option-menu-list/OptionMenuList.js
+++ b/packages/react-components/test/option-menu-list/OptionMenuList.js
@@ -1,0 +1,288 @@
+import '../setup';
+import { expect } from 'chai';
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+import OptionMenuList from '../../source/react/internal/option-menu-list';
+import OptionMenuListItem from '../../source/react/internal/option-menu-list/OptionMenuListItem';
+
+import {
+  DOWN_KEY_CODE,
+  END_KEY_CODE,
+  ENTER_KEY_CODE,
+  HOME_KEY_CODE,
+  SPACE_KEY_CODE,
+  UP_KEY_CODE,
+} from '../../source/react/constants';
+
+const options = [
+  { value: 'peach', label: 'peach' },
+  { value: 'pear', label: 'pear' },
+  { value: 'apple', label: 'apple', disabled: true },
+];
+
+const lastIndex = options.length - 1;
+
+const getChoiceByText = (wrapper, text) =>
+  wrapper.find(OptionMenuListItem).filterWhere(n => n.text() === text);
+
+const getNthChoice = (wrapper, n) =>
+  wrapper
+    .find(OptionMenuListItem)
+    .filterWhere(node => node.prop('type') !== 'heading')
+    .at(n);
+
+describe('<OptionMenuList />', () => {
+  it('is empty when no options are provided', () => {
+    const wrapper = shallow(<OptionMenuList id="test" />);
+    expect(wrapper.isEmptyRender()).to.equal(true);
+  });
+
+  it('still renders when options are available but empty', () => {
+    const wrapper = shallow(
+      <OptionMenuList id="test" name="select-example-one" options={[]} />,
+    );
+    wrapper.unmount();
+    expect(wrapper.length).to.equal(1);
+  });
+
+  it('focuses the first item by default', () => {
+    const wrapper = shallow(<OptionMenuList id="test" options={options} />);
+    const firstItem = wrapper.find(OptionMenuListItem).first();
+    expect(firstItem.prop('focused')).to.equal(true);
+    expect(firstItem.prop('selected')).to.equal(false);
+    expect(
+      wrapper
+        .find('ul')
+        .first()
+        .prop('aria-activedescendant'),
+    ).to.equal(firstItem.prop('id'));
+  });
+
+  it('allows focus but prevents select on disabled items', () => {
+    const wrapper = shallow(<OptionMenuList id="test" options={options} />);
+
+    getChoiceByText(wrapper, 'apple').simulate('mouseenter');
+    expect(getChoiceByText(wrapper, 'apple').prop('focused')).to.equal(
+      true,
+    );
+
+    getChoiceByText(wrapper, 'apple').simulate('click');
+    expect(getChoiceByText(wrapper, 'apple').prop('selected')).to.equal(
+      false,
+    );
+  });
+
+  it('calls click handlers on click', () => {
+    const onClick = sinon.spy();
+    const onChange = sinon.spy();
+
+    const wrapper = mount(
+      <OptionMenuList
+        id="test"
+        options={options}
+        onClickItem={onClick}
+        onChange={onChange}
+      />,
+    );
+
+    getChoiceByText(wrapper, 'pear').simulate('click');
+
+    expect(onClick.calledOnce).to.equal(true);
+    expect(onChange.calledWith('pear')).to.equal(true);
+  });
+
+  it('does not call click handlers when the clicked option is disabled', () => {
+    const onClick = sinon.spy();
+    const onChange = sinon.spy();
+
+    const wrapper = mount(
+      <OptionMenuList
+        id="test"
+        options={options}
+        onClickItem={onClick}
+        onChange={onChange}
+      />,
+    );
+
+    getChoiceByText(wrapper, 'apple').simulate('click');
+    expect(onClick.called).to.equal(false);
+    expect(onChange.called).to.equal(false);
+  });
+
+  describe('keyboard navigation', () => {
+    const pressKey = (wrapper, keyCode, times = 1) => {
+      const eventObj = {
+        keyCode,
+        preventDefault: sinon.spy(),
+        stopPropagation: sinon.spy(),
+      };
+
+      new Array(times).fill(null).forEach(() => {
+        wrapper
+          .find('ul')
+          .first()
+          .prop('onKeyDown')(eventObj);
+      });
+
+      return eventObj;
+    };
+
+    const MANY_TIMES = 8; // (more times than the number of focusable items in these examples)
+
+    it('focuses the next item on down arrow', () => {
+      const onFocusItem = sinon.spy();
+      const wrapper = mount(
+        <OptionMenuList
+          id="test"
+          options={options}
+          onFocusItem={onFocusItem}
+        />,
+      );
+
+      expect(getNthChoice(wrapper, 0).prop('focused')).to.equal(true);
+
+      pressKey(wrapper, DOWN_KEY_CODE);
+      expect(onFocusItem.calledWith(1)).to.equal(true);
+      expect(wrapper.state('focusedIndex')).to.equal(1);
+
+      pressKey(wrapper, DOWN_KEY_CODE, MANY_TIMES);
+      expect(wrapper.state('focusedIndex')).to.equal(options.length - 1);
+    });
+
+    it('focuses the previous item on up arrow', () => {
+      const onFocusItem = sinon.spy();
+      const wrapper = mount(
+        <OptionMenuList
+          id="test"
+          options={options}
+          onFocusItem={onFocusItem}
+          focusedIndex={lastIndex}
+        />,
+      );
+
+      expect(getNthChoice(wrapper, lastIndex).prop('focused')).to.equal(true);
+
+      pressKey(wrapper, UP_KEY_CODE);
+      expect(onFocusItem.calledWith(lastIndex - 1)).to.equal(true);
+      expect(wrapper.state('focusedIndex')).to.equal(lastIndex - 1);
+
+      pressKey(wrapper, UP_KEY_CODE, MANY_TIMES);
+      expect(wrapper.state('focusedIndex')).to.equal(0);
+    });
+
+    it('focuses the top item on home', () => {
+      const onFocusItem = sinon.spy();
+      const wrapper = mount(
+        <OptionMenuList
+          id="test"
+          options={options}
+          onFocusItem={onFocusItem}
+          focusedIndex={3}
+        />,
+      );
+
+      pressKey(wrapper, HOME_KEY_CODE);
+      expect(wrapper.state('focusedIndex')).to.equal(0);
+    });
+
+    it('focuses the bottom item on end', () => {
+      const onFocusItem = sinon.spy();
+      const wrapper = mount(
+        <OptionMenuList
+          id="test"
+          options={options}
+          onFocusItem={onFocusItem}
+          focusedIndex={1}
+        />,
+      );
+
+      pressKey(wrapper, END_KEY_CODE);
+      expect(wrapper.state('focusedIndex')).to.equal(lastIndex);
+    });
+
+    it('calls click handlers for the focused item on enter or space', () => {
+      const onClick = sinon.spy();
+      const onChange = sinon.spy();
+
+      const wrapper = mount(
+        <OptionMenuList
+          id="test"
+          options={options}
+          onClickItem={onClick}
+          onChange={onChange}
+          focusedIndex={0}
+        />,
+      );
+
+      pressKey(wrapper, ENTER_KEY_CODE);
+      expect(onClick.calledOnce).to.equal(true);
+      expect(onChange.calledWith('peach')).to.equal(true);
+    });
+
+    it('does not call click handlers for a disabled item on enter or space', () => {
+      const onClick = sinon.spy();
+      const onChange = sinon.spy();
+
+      const wrapper = mount(
+        <OptionMenuList
+          id="test"
+          options={options}
+          onClickItem={onClick}
+          onChange={onChange}
+          focusedIndex={2}
+        />,
+      );
+
+      pressKey(wrapper, ENTER_KEY_CODE);
+      pressKey(wrapper, SPACE_KEY_CODE);
+
+      expect(onClick.called).to.equal(false);
+      expect(onChange.called).to.equal(false);
+    });
+  });
+
+  describe('with multiple select', () => {
+    it('sends all selected values to click handlers', () => {
+      const onClick = sinon.spy();
+      const onChange = sinon.spy();
+
+      const wrapper = mount(
+        <OptionMenuList
+          id="test"
+          options={options}
+          onClickItem={onClick}
+          onChange={onChange}
+          selected={['pear']}
+          multiple
+        />,
+      );
+
+      getChoiceByText(wrapper, 'peach').simulate('click');
+
+      expect(onChange.calledWith(['pear', 'peach'])).to.equal(true);
+      expect(onClick.calledOnce).to.equal(true);
+    });
+
+    it('toggles selection of an already selected value when it is clicked a second time', () => {
+      const onClick = sinon.spy();
+      const onChange = sinon.spy();
+
+      const wrapper = mount(
+        <OptionMenuList
+          id="test"
+          options={options}
+          onClickItem={onClick}
+          onChange={onChange}
+          selected={['peach', 'pear']}
+          multiple
+        />,
+      );
+
+      getChoiceByText(wrapper, 'pear').simulate('click');
+
+      expect(onChange.calledWith(['peach'])).to.equal(true);
+      expect(onClick.calledOnce).to.equal(true);
+    });
+  });
+});

--- a/packages/react-components/test/select/Select.js
+++ b/packages/react-components/test/select/Select.js
@@ -1,8 +1,12 @@
-import chai, { expect } from 'chai';
+import '../setup';
+import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow, mount } from 'enzyme';
-import React from 'react';
+import React, { useState } from 'react';
 import Select from '../../source/react/library/select/Select';
+import SelectTarget from '../../source/react/library/select/SelectTarget';
+import OptionMenuList from '../../source/react/internal/option-menu-list';
+import OptionMenuListItem from '../../source/react/internal/option-menu-list/OptionMenuListItem';
 
 const options = [
   { value: 'apple', label: 'apple' },
@@ -15,6 +19,26 @@ const options = [
   { value: 'strawberry', label: 'strawberry' },
   { value: 'raspberry', label: 'raspberry' },
 ];
+
+// eslint-disable-next-line react/prop-types
+const ExampleSelect = ({ value: initialValue, ...props }) => {
+  const [value, setValue] = useState(initialValue || null);
+
+  return (
+    <Select
+      name="test"
+      value={value}
+      onChange={val => {
+        setValue(val);
+      }}
+      open
+      {...props}
+    />
+  );
+};
+
+const getChoiceByText = (wrapper, text) =>
+  wrapper.find(OptionMenuListItem).filterWhere(n => n.text() === text);
 
 describe('<Select />', () => {
   it('should render without falling over', () => {
@@ -60,5 +84,104 @@ describe('<Select />', () => {
       .onBlur();
     expect(onBlur.called).to.equal(true);
     wrapper.unmount();
+  });
+
+  it('starts with the listbox closed and shows it when the target button is clicked', () => {
+    const wrapper = mount(<Select name="test" options={options} />);
+    expect(wrapper.find(Select).state('open')).to.equal(false);
+
+    const menu = wrapper.find(OptionMenuList);
+    expect(menu.prop('aria-labelledby')).to.equal('test-label');
+    expect(menu.prop('role')).to.equal('listbox');
+
+    const target = wrapper.find(SelectTarget);
+    expect(target.prop('aria-controls')).to.equal('test-menu');
+    expect(target.prop('aria-haspopup')).to.equal('listbox');
+    expect(target.prop('aria-expanded')).to.equal(false);
+
+    target.find('button').simulate('click');
+
+    expect(wrapper.find(SelectTarget).prop('aria-expanded')).to.equal(true);
+    expect(wrapper.find(Select).state('open')).to.equal(true);
+  });
+
+  it('selects an option on click', () => {
+    const wrapper = mount(<ExampleSelect name="test" options={options} open />);
+
+    getChoiceByText(wrapper, 'kiwi').simulate('click');
+    expect(wrapper.find(OptionMenuList).prop('selected')).to.equal('kiwi');
+    expect(wrapper.find('input').prop('value')).to.equal('kiwi');
+    expect(wrapper.find(SelectTarget).text()).to.equal('kiwi');
+    expect(wrapper.find(Select).state('open')).to.equal(false);
+  });
+
+  it('does _not_ deselect the option on second click', () => {
+    const wrapper = mount(<ExampleSelect name="test" options={options} open />);
+
+    getChoiceByText(wrapper, 'kiwi').simulate('click');
+    wrapper.find(SelectTarget).simulate('click');
+    getChoiceByText(wrapper, 'kiwi').simulate('click');
+
+    expect(wrapper.find(OptionMenuList).prop('selected')).to.equal('kiwi');
+    expect(wrapper.find('input').prop('value')).to.equal('kiwi');
+    expect(wrapper.find(SelectTarget).text()).to.equal('kiwi');
+  });
+
+  describe('with multiselect', () => {
+    const getApplyButton = wrapper =>
+      wrapper
+        .find('button')
+        .filterWhere(n => n.text() === 'Apply')
+        .first();
+
+    it('allows selection of multiple items on click + Apply', () => {
+      const wrapper = mount(
+        <ExampleSelect name="test" options={options} type="multiselect" open />,
+      );
+      const selections = ['banana', 'kiwi'];
+
+      selections.forEach(item => {
+        getChoiceByText(wrapper, item).simulate('click');
+      });
+      getApplyButton(wrapper).simulate('click');
+
+      expect(wrapper.find(OptionMenuList).prop('selected')).to.eql(selections);
+      expect(wrapper.find(SelectTarget).text()).to.equal(selections.join(', '));
+      expect(wrapper.find('input').prop('value')).to.eql(selections);
+    });
+
+    it('deselects a selected item on second click + Apply', () => {
+      const wrapper = mount(
+        <ExampleSelect name="test" options={options} type="multiselect" open />,
+      );
+
+      getChoiceByText(wrapper, 'banana').simulate('click');
+      getChoiceByText(wrapper, 'kiwi').simulate('click');
+      getApplyButton(wrapper).simulate('click');
+      getChoiceByText(wrapper, 'kiwi').simulate('click');
+      getApplyButton(wrapper).simulate('click');
+
+      expect(wrapper.find(OptionMenuList).prop('selected')).to.eql(['banana']);
+      expect(wrapper.find(SelectTarget).text()).to.equal('banana');
+      expect(wrapper.find('input').prop('value')).to.eql(['banana']);
+    });
+
+    it('applies selections without requiring the Apply button when applyImmediately is set', () => {
+      const wrapper = mount(
+        <ExampleSelect
+          name="test"
+          options={options}
+          type="multiselect"
+          applyImmediately
+          open
+        />,
+      );
+
+      getChoiceByText(wrapper, 'kiwi').simulate('click');
+
+      expect(wrapper.find(OptionMenuList).prop('selected')).to.eql(['kiwi']);
+      expect(wrapper.find(SelectTarget).text()).to.equal('kiwi');
+      expect(wrapper.find('input').prop('value')).to.eql(['kiwi']);
+    });
   });
 });


### PR DESCRIPTION
This PR implements option groups for the Select component (and by extension, the OptionMenuList component) - I've been working off of [this design for the forge](https://www.figma.com/file/8eYn03ZmD3WPqDC0IlbHq6/Search-results?node-id=2634%3A7024).

In short, this makes it so that for Select components, if you specify an array of options as an option value, the array items will be the child options, and the parent's label will be the option group title. I have not enabled focus or click/select events for group titles (but happy to do so if wanted).

This was a pretty large change, but I added several new tests for OptionMenuList and Select to try to ensure all existing behavior stayed the same. This also fixes a small bug in Select where disabled items could be selected via keyboard.
