### PR TITLE
Return placeholder if selected option in Select is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# react-components 5.29.2 (2021-07-07)
+
+- [Icon] Add plus-circle-filled by in (by [@cathal41](https://github.com/cathal41) in [#447](https://github.com/puppetlabs/design-system/pull/447))
+- [Select] Show placeholder instead of throwing error if value isn't present in options (by [@vine77](https://github.com/vine77) in [#448](https://github.com/puppetlabs/design-system/pull/448))
+
 # data-grid 0.5.4 (2021-03-09)
 
 - Fix Page Bug (by [@Lukeaber](https://github.com/Lukeaber) in [#437](https://github.com/puppetlabs/design-system/pull/437))

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.29.1",
+  "version": "5.29.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.29.1",
+  "version": "5.29.2",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/react/library/select/Select.js
+++ b/packages/react-components/source/react/library/select/Select.js
@@ -283,6 +283,7 @@ class Select extends Component {
 
   getButtonLabel() {
     const { type, value, placeholder } = this.props;
+
     if (!value || value.length === 0) {
       return placeholder;
     }
@@ -298,6 +299,10 @@ class Select extends Component {
     const selectedOption = this.getOptions().find(
       option => option.value === value,
     );
+
+    if (!selectedOption) {
+      return placeholder;
+    }
 
     return selectedOption.label;
   }

--- a/packages/react-components/source/react/library/select/Select.md
+++ b/packages/react-components/source/react/library/select/Select.md
@@ -8,13 +8,13 @@ The Select component is a form element allowing for selection of a value or set 
 
 ## Basic use
 
-Options are specified by entries in an `options` array prop. Each requires a unique value and a friendly label to display to users.
+Options are specified by entries in an `options` array prop, each of which requires a unique `value` and a friendly `label` to display to users.
 
 ```jsx
+const [value, setValue] = React.useState('');
+
 const options = [
-  { value: 'en', label: 'English' },
-  { value: 'ru', label: 'русский' },
-  { value: 'zh', label: '中文' },
+  { value: 'af', label: 'Afrikaans' },
   { value: 'sq', label: 'Albanian' },
   { value: 'ar', label: 'Arabic' },
   { value: 'eu', label: 'Basque' },
@@ -24,21 +24,45 @@ const options = [
   { value: 'ca', label: 'Catalan' },
 ];
 
-const style = { margin: 10 };
+<Select
+  name="select-example"
+  placeholder="Select your language"
+  options={options}
+  value={value}
+  onChange={newValue => setValue(newValue)}
+/>
+```
 
-<div>
+### Nonexistent value
+
+Note that if the `value` you pass is not present in the list of `options`, the value isn't cleared but the Select will only show the placeholder, so extra handling may need to be done in that case depending on the application.
+
+```jsx
+import Alert from '../Alert';
+
+const [value, setValue] = React.useState('eo');
+const options = [
+  { value: 'af', label: 'Afrikaans' },
+  { value: 'sq', label: 'Albanian' },
+  { value: 'ar', label: 'Arabic' },
+  { value: 'eu', label: 'Basque' },
+  { value: 'bn', label: 'Bengali' },
+  { value: 'bs', label: 'Bosnian' },
+  { value: 'bg', label: 'Bulgarian' },
+  { value: 'ca', label: 'Catalan' },
+];
+const isValueInOptions = options.map(option => option.value).includes(value);
+
+<>
   <Select
     name="select-example"
-    options={options}
     placeholder="Select your language"
-    style={style}
-    value={state.value1}
-    onChange={value1 => {
-      console.log('New Value:', value1);
-      setState({ value1 });
-    }}
+    options={options}
+    value={value}
+    onChange={newValue => setValue(newValue)}
   />
-</div>;
+  {!isValueInOptions && <Alert type="warning" style={{ marginTop: 10 }}>"{value}" is not an option</Alert>}
+</>
 ```
 
 ## Variations


### PR DESCRIPTION
Add fallback (to `placeholder`) if `value` is not found in Select `options`.

This fixes Select so that passing a value not in options doesn't cause an exception:

```jsx
<Select
  name="select-example"
  placeholder="Select your language"
  options={[{ value: 'en', label: 'English' }]}
  value="es"
/>
```

Before:

<img width="1023" alt="Screen Shot 2021-07-06 at 3 55 37 PM" src="https://user-images.githubusercontent.com/175123/124676226-f69c2b80-de72-11eb-8c93-ecd0457da64c.png">

After:

<img width="1023" alt="Screen Shot 2021-07-06 at 3 57 07 PM" src="https://user-images.githubusercontent.com/175123/124676233-fa2fb280-de72-11eb-9cdd-aa7a021c1afc.png">
