### PR TITLE
Fix form label spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,18 @@
+# react-components 6.0.0-alpha.7 (2021-07-20)
+
+- [Form] Fix form label spacing #452
 # react-components 6.0.0-alpha.6 (2021-07-14)
 
-- BREAKING [Columns] Move Columns from react-layouts to react-components
+- BREAKING [Columns] Move Columns from react-layouts to react-components #451
 
 # react-components 6.0.0-alpha.5 (2021-07-12)
 
-- [List] Add List component
-- BREAKING [Filters] Remove the old undocumented Filters component
+- [List] Add List component #446
+- BREAKING [Filters] Remove the old undocumented Filters component #446
 
 # react-components 6.0.0-alpha.4 (2021-07-12)
 
-- Upgrade dependencies
+- Upgrade dependencies #450
 
 # react-components 5.29.2 (2021-07-07)
 

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "6.0.0-alpha.6",
+  "version": "6.0.0-alpha.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "6.0.0-alpha.6",
+  "version": "6.0.0-alpha.7",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/scss/library/components/forms/_forms.scss
+++ b/packages/react-components/source/scss/library/components/forms/_forms.scss
@@ -78,15 +78,15 @@ $puppet-form-inline-label-gutter-width: $puppet-common-spacing-base * 12 !defaul
 .rc-form-field-label {
   display: block;
   letter-spacing: $puppet-type-spacing-medium;
-  line-height: $puppet-common-spacing-base * 5 !important;
 
   &.rc-form-field-label-primary {
     @include puppet-type-label(medium);
+    line-height: calc(20 / 11);
   }
 
   &.rc-form-field-label-secondary {
     @include puppet-type-h6(medium);
-    font-weight: $puppet-type-weight-heavy;
+    line-height: calc(26 / 16);
   }
 
   &.rc-form-field-label-not-visible {
@@ -148,6 +148,7 @@ $puppet-form-inline-label-gutter-width: $puppet-common-spacing-base * 12 !defaul
 .rc-form-field-inline {
   .rc-form-field-label {
     flex-shrink: 0;
+    line-height: calc(32/11);
     margin: 0;
     overflow: hidden;
     padding-right: $puppet-form-inline-label-gutter-width;
@@ -156,8 +157,11 @@ $puppet-form-inline-label-gutter-width: $puppet-common-spacing-base * 12 !defaul
     width: $puppet-form-inline-label-column-width;
   }
 
+  .rc-form-field-label-secondary {
+    line-height: calc(32/16);
+  }
+
   .rc-form-field-content {
-    align-items: center;
     display: flex;
   }
 


### PR DESCRIPTION
- Fix incorrect vertical centering, which caused spacing problems when extra info or errors were displayed below inputs
	- For `<Form inline />`, labels should now be aligned with the input instead of centered in the whole row.
- Remove usage of !important
- Update line-height depending on font size

<img width="1196" alt="Screen Shot 2021-07-19 at 7 47 09 PM" src="https://user-images.githubusercontent.com/175123/126254310-a5f2da3c-21c5-4c49-a68f-e1b8e56e0e44.png">
