### PR TITLE
Allow empty `children` in Copy component

### DIFF
--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "6.0.0-alpha.8",
+  "version": "6.0.0-alpha.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "6.0.0-alpha.8",
+  "version": "6.0.0-alpha.9",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/react/library/copy/Copy.js
+++ b/packages/react-components/source/react/library/copy/Copy.js
@@ -72,7 +72,7 @@ const Copy = ({
 
   return (
     <div className={classNames('copy', `copy-${align}`, className)}>
-      <div className="copy-input">{children}</div>
+      {children && <div className="copy-input">{children}</div>}
       <Button
         icon="copy"
         className="value-copy-button"

--- a/packages/react-components/source/react/library/copy/Copy.md
+++ b/packages/react-components/source/react/library/copy/Copy.md
@@ -6,11 +6,43 @@ The value to copy may be set in the `value` prop. This `value` supercedes all fo
 
 If no `value` prop is set, a child React element will be checked for a `value` prop or a text node child. The `value` prop supersedes the text node in this case. A plain text node child may be provided instead of a React element, in which case the text will be used as the `value`. If none of the above are set, the component will return `null`.
 
-See also: [Code](#/React%20Components/Code) and [FormField](#/React%20Components/FormField)
+### Basic use
+
+Pass the value to be displayed and copied as `children`:
 
 ```jsx
 <Copy>Important text to copy</Copy>
 ```
+
+Or to just display the copy button but not render the value next to it, use the `value` prop without `children`:
+
+```jsx
+<Copy value="Important text to copy but not display" />
+```
+
+### Types
+
+A type of `block` will style the content like `<Code type="block">`.
+
+```jsx
+import Code from '../code';
+
+<Code type="block">
+  <Copy>mod 'puppetlabs-stdlib', '6.3.0'</Copy>
+</Code>;
+```
+
+### Variations
+
+#### Copy a different value than displayed
+
+```jsx
+<Copy value="areallyreallylongstringthatyouaren'tdisplayinginfull">
+  areallyreally...
+</Copy>
+```
+
+#### Modify value copied with a function
 
 ```jsx
 <Copy
@@ -25,19 +57,7 @@ See also: [Code](#/React%20Components/Code) and [FormField](#/React%20Components
 </Copy>
 ```
 
-```jsx
-<Copy value="areallyreallylongstringthatyouaren'tdisplayinginfull">
-  areallyreally...
-</Copy>
-```
-
-```jsx
-import Code from '../code';
-
-<Code type="block">
-  <Copy>mod 'puppetlabs-stdlib', '6.3.0'</Copy>
-</Code>;
-```
+### Use in forms
 
 ```jsx
 import Form from '../form';


### PR DESCRIPTION
- Don't render the `.copy-input` div if `children` is empty, allowing `<Copy value="value to copy" />` to render just the button.
- Update Copy docs

This PR targets the alpha release.