### PR TITLE
MAINT - Warning message for accessability in Icon component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# react-components 5.29.4 (2021-09-27)
+
+- [Icon] Add accessibility warning message to Icon docs (by [@cathal](https://github.com/cathal41) in [#466](https://github.com/puppetlabs/design-system/pull/466))
+
 # react-components 5.29.3 (2021-08-23)
 
 - [Stepper] Add Stepper container component (by [@desmondbera](https://github.com/desmondbera)

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.29.3",
+  "version": "5.29.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.29.3",
+  "version": "5.29.4",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/react/library/icon/Icon.md
+++ b/packages/react-components/source/react/library/icon/Icon.md
@@ -1,8 +1,12 @@
-**Warning: Icons render as svg's and cannot be accessed with tabs or screen reader software, please use the [Button](#/React%20Components/Button) component with type "transparent" and an icon prop to add an interactive icon.**
-
 ## Overview
 
 Icons and logos are designed to have consistency in style and spacing. They are output as SVG elements and wrapped in components.
+
+### Accessibility
+
+**Warning**: Be aware that icons render as SVGs that cannot be accessed with tabs or screen reader software. For interactivity, consider using the [Button](#/React%20Components/Button) component with the `icon` prop and a `type` of "transparent".
+
+See also: [Button](#/React%20Components/Button) and [Button Select](#/React%20Components/ButtonSelect)
 
 ### Rendering Icons
 
@@ -15,8 +19,6 @@ The specific SVG rendered is decided by the following:
 
 1. If there is a unique SVG for the type and size provided, it will be rendered. Unique SVGs are indicated by a green background below.
 2. Otherwise, we scale down the next largest SVG, or if unavailable, scale up the next smallest SVG.
-
-See also: [Button](#/React%20Components/Button) and [Button Select](#/React%20Components/ButtonSelect)
 
 ## Basic Use
 

--- a/packages/react-components/source/react/library/icon/Icon.md
+++ b/packages/react-components/source/react/library/icon/Icon.md
@@ -1,3 +1,5 @@
+**Warning: Icons render as svg's and cannot be accessed with tabs or screen reader software, please use the [Button](#/React%20Components/Button) component with type "transparent" and an icon prop to add an interactive icon.**
+
 ## Overview
 
 Icons and logos are designed to have consistency in style and spacing. They are output as SVG elements and wrapped in components.


### PR DESCRIPTION
Adding a warning message to the top of the icons page, same as the logo page, to indicate to user they should use a button rather than an Icon to make and interactive component