### PR TITLE
Fix data-grid bug in handling non-extensible objects with shallow clone for row data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,12 @@
 name: Test
 
-on: [pull_request]
+on:
+  push:
+    paths-ignore:
+      - '*.md'
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -12,10 +14,10 @@ jobs:
         node-version: [12.4.0]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/packages/data-grid/package-lock.json
+++ b/packages/data-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@puppet/data-grid",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/data-grid/package.json
+++ b/packages/data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/data-grid",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/packages/data-grid/src/__test__/Table.test.jsx
+++ b/packages/data-grid/src/__test__/Table.test.jsx
@@ -6,24 +6,24 @@ import Table from '../table/Table';
 configure({ adapter: new Adapter() });
 
 const data = [
-  { id: 1, eventType: 'Virus/Malware', affectedDevices: 20, detections: 634 },
+  { id: 0, eventType: 'Virus/Malware', affectedDevices: 20, detections: 634 },
   {
-    id: 2,
+    id: 1,
     eventType: 'Spyware/Grayware',
     affectedDevices: 20,
     detections: 634,
   },
-  { id: 3, eventType: 'URL Filtering', affectedDevices: 15, detections: 598 },
-  { id: 4, eventType: 'Web Reputation', affectedDevices: 15, detections: 598 },
-  { id: 5, eventType: 'Network Virus', affectedDevices: 15, detections: 497 },
+  { id: 2, eventType: 'URL Filtering', affectedDevices: 15, detections: 598 },
+  { id: 3, eventType: 'Web Reputation', affectedDevices: 15, detections: 598 },
+  { id: 4, eventType: 'Network Virus', affectedDevices: 15, detections: 497 },
   {
-    id: 6,
+    id: 5,
     eventType: 'Application Control',
     affectedDevices: 0,
     detections: 0,
   },
   {
-    id: 7,
+    id: 6,
     eventType: 'Application Control',
     affectedDevices: 0,
     detections: 0,

--- a/packages/data-grid/src/table/Table.jsx
+++ b/packages/data-grid/src/table/Table.jsx
@@ -117,15 +117,13 @@ const defaultColumnDefs = {
 
 class Table extends Component {
   uniqueIDCheck = (rowKey, rowData, rowIndex) => {
-    if (rowKey === undefined) {
-      const newRowData = rowData;
-      newRowData.id = rowIndex;
-      return newRowData.id;
-    }
     if (typeof rowKey === 'string') {
       return rowData[rowKey];
     }
-    return rowKey(rowData);
+    if (typeof rowKey === 'function') {
+      return rowKey(rowData);
+    }
+    return rowIndex;
   };
 
   classNameTypeManage = (classname, data, index) => {


### PR DESCRIPTION
Don't extend rowData object when creating key. This fixes a bug when the data passed in has been marked as non-extensible (e.g. as occurs with Redux Toolkit or immer's use of Object.freeze). The data-grid Table was trying to add an id property to the passed object, which doesn't seem necessary just to calculate a React key, so it removes that.