### PR TITLE
Add max width to tooltip and center text

### DIFF
--- a/packages/react-components/source/scss/library/components/_tooltips.scss
+++ b/packages/react-components/source/scss/library/components/_tooltips.scss
@@ -20,13 +20,14 @@ $puppet-caret-vertical-offset: calc(100% + #{$puppet-tooltip-caret-total-width})
   background-color: $puppet-tooltip-hint-bg;
   border-radius: $puppet-tooltip-hint-radius;
   color: $puppet-tooltip-hint-color;
+  max-width: 200px;
   opacity: 0;
   padding: $puppet-tooltip-hint-padding;
   position: absolute;
+  text-align: center;
   transition: opacity, $puppet-common-transition-duration ease-in-out;
   visibility: hidden;
-  white-space: nowrap;
-  width: fit-content;
+  width: max-content;
   z-index: $puppet-tooltip-hint-elevation;
 }
 


### PR DESCRIPTION
TooltipHoverArea:
 - Add max width of 200px
 - Center align text
 - Allow text to wrap if larger than 200px

<img width="780" alt="Screen Shot 2021-10-29 at 2 23 59 PM" src="https://user-images.githubusercontent.com/15816694/139506629-0cee3127-68f5-4956-8bca-fda61c5d7ef1.png">
<img width="717" alt="Screen Shot 2021-10-29 at 2 14 17 PM" src="https://user-images.githubusercontent.com/15816694/139506648-0d0c5626-18c0-44e1-b04b-5f1118cd5a8b.png">
