### PR TITLE
Make Form.Field's label prop optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NEXT react-components alpha
+
+- [Form.Field] Make Form.Field's label prop optional
+
 # react-components 6.0.0-alpha.16 (2022-03-30)
 
 - Merge 5.33.5 into alpha

--- a/packages/react-components/source/react/library/form/FormField.js
+++ b/packages/react-components/source/react/library/form/FormField.js
@@ -15,7 +15,7 @@ const propTypes = {
   /** A unique identifier for this field */
   name: PropTypes.string.isRequired,
   /** A human-friendly identifier for this field */
-  label: PropTypes.node.isRequired,
+  label: PropTypes.node,
   /** The styling of the identifier for this field */
   labelType: PropTypes.oneOf(['primary', 'secondary']),
   /** Depending on the field, value can be any type */
@@ -54,6 +54,7 @@ const propTypes = {
 
 const defaultProps = {
   labelType: null,
+  label: '',
   value: undefined,
   error: '',
   description: '',


### PR DESCRIPTION
In the `<Form.Field>` component, the `label` prop is hidden if empty, this PR marks it as not required to avoid console warnings.