### PR TITLE
Tooltip fixes & updates 

### DIFF
--- a/packages/react-components/source/index.js
+++ b/packages/react-components/source/index.js
@@ -37,7 +37,7 @@ import Tabs from './react/library/tabs';
 import Tag from './react/library/tag';
 import Text from './react/library/text';
 import Toolbar from './react/library/toolbar';
-import TooltipHoverArea from './react/library/tooltips/TooltipHoverArea';
+import TooltipHoverArea from './react/library/tooltips';
 import Overlay from './react/library/overlay';
 
 export {

--- a/packages/react-components/source/react/library/portal/portal.js
+++ b/packages/react-components/source/react/library/portal/portal.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  target: PropTypes.oneOf(['tooltip']),
+};
+const Portal = ({ children, target = 'tooltip' }) => {
+  const root = document.getElementsByClassName('app')[0];
+  const portalId = `portal-${target}`;
+  let portal = document.getElementById(portalId);
+  if (!portal) {
+    portal = document.createElement('div');
+    portal.id = portalId;
+    root.appendChild(portal);
+  }
+  return createPortal(children, portal);
+};
+Portal.propTypes = propTypes;
+export default Portal;

--- a/packages/react-components/source/react/library/portal/portal.js
+++ b/packages/react-components/source/react/library/portal/portal.js
@@ -6,7 +6,7 @@ const propTypes = {
 };
 
 const Portal = ({ children, target = 'tooltip' }) => {
-  //portal target with fallbacks
+  // portal target with fallbacks
   const root =
     document.getElementsByClassName('app')[0] ??
     document.getElementById('root') ??
@@ -18,7 +18,7 @@ const Portal = ({ children, target = 'tooltip' }) => {
   if (!portal && root) {
     portal = document.createElement('div');
     portal.id = portalId;
-    root?.appendChild(portal);
+    root.appendChild(portal);
   }
   return createPortal(children, portal);
 };

--- a/packages/react-components/source/react/library/portal/portal.js
+++ b/packages/react-components/source/react/library/portal/portal.js
@@ -6,14 +6,19 @@ const propTypes = {
 };
 
 const Portal = ({ children, target = 'tooltip' }) => {
-  const root = document.getElementById('root');
+  //portal target with fallbacks
+  const root =
+    document.getElementsByClassName('app')[0] ??
+    document.getElementById('root') ??
+    document.body;
+
   const portalId = `portal-${target}`;
   let portal = document.getElementById(portalId);
 
-  if (!portal) {
+  if (!portal && root) {
     portal = document.createElement('div');
     portal.id = portalId;
-    root.appendChild(portal);
+    root?.appendChild(portal);
   }
   return createPortal(children, portal);
 };

--- a/packages/react-components/source/react/library/portal/portal.js
+++ b/packages/react-components/source/react/library/portal/portal.js
@@ -6,9 +6,10 @@ const propTypes = {
 };
 
 const Portal = ({ children, target = 'tooltip' }) => {
-  const root = document.getElementsByClassName('app')[0];
+  const root = document.getElementById('root');
   const portalId = `portal-${target}`;
   let portal = document.getElementById(portalId);
+
   if (!portal) {
     portal = document.createElement('div');
     portal.id = portalId;

--- a/packages/react-components/source/react/library/portal/portal.js
+++ b/packages/react-components/source/react/library/portal/portal.js
@@ -1,10 +1,10 @@
-import React from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 
 const propTypes = {
   target: PropTypes.oneOf(['tooltip']),
 };
+
 const Portal = ({ children, target = 'tooltip' }) => {
   const root = document.getElementsByClassName('app')[0];
   const portalId = `portal-${target}`;

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -116,20 +116,20 @@ const TooltipHoverArea = ({
   // Manage tooltip visibility
   const mouseIn = () => {
     // popper.js doesn't take into account layout changes, so we need to update it manually
-    // eslint-disable-next-line
-    update?.();
-    !disabled && showTooltip();
+    update();
+    if (!disabled) showTooltip();
   };
   const mouseOut = () => hideTooltip();
 
   useEffect(() => {
-    disabled && hideTooltip();
+    if (disabled) hideTooltip();
   }, [disabled, children, referenceElement]);
 
   return (
     <>
       {!!children && !!tooltip && (
         <Portal>
+          {/* eslint-disable-next-line */}
           <div
             className={classNames('rc-tooltip', className)}
             ref={setPopperElement}

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -10,7 +10,7 @@ export const propTypes = {
   /** Optional onClick for the activating element */
   onClick: PropTypes.func,
   /** The content of the tooltip */
-  tooltip: PropTypes.node.isRequired,
+  tooltip: PropTypes.node,
   /** The activating element for the tooltip */
   children: PropTypes.node.isRequired,
   /** Optional additional className */
@@ -36,6 +36,7 @@ export const defaultProps = {
   arrow: true,
   position: 'fixed',
   textAlign: 'center',
+  tooltip: null,
 };
 
 /**

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -125,12 +125,15 @@ const TooltipHoverArea = ({
     if (disabled) hideTooltip();
   }, [disabled, children, referenceElement]);
 
+  // unique id for aria-tooltip
+  const tooltipId = `tooltip-${Math.floor(Math.random() * 10000)}`;
   return (
     <>
       {!!children && !!tooltip && (
         <Portal>
           {/* eslint-disable-next-line */}
           <div
+            id={tooltipId}
             className={classNames('rc-tooltip', className)}
             ref={setPopperElement}
             style={{ ...styles.popper, textAlign, maxWidth, ...style }}
@@ -154,7 +157,7 @@ const TooltipHoverArea = ({
       )}
       <div
         ref={setReferenceElement}
-        aria-describedby={classNames('rc-tooltip', className)}
+        aria-describedby={tooltipId}
         className="rc-tooltip-reference"
         onMouseEnter={mouseIn}
         onFocus={mouseIn}

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { usePopper } from 'react-popper';
@@ -62,7 +62,9 @@ const TooltipHoverArea = ({
   const [arrowElement, setArrowReference] = useState(null);
   const [referenceElement, setReferenceElement] = useState(null);
   const [popperElement, setPopperElement] = useState(null);
-
+  const { current: tooltipId } = useRef(
+    `tooltip-${Math.floor(Math.random() * 10000)}`,
+  );
   const popperModifiers = [
     {
       name: 'flip',
@@ -125,8 +127,6 @@ const TooltipHoverArea = ({
     if (disabled) hideTooltip();
   }, [disabled, children, referenceElement]);
 
-  // unique id for aria-tooltip
-  const tooltipId = `tooltip-${Math.floor(Math.random() * 10000)}`;
   return (
     <>
       {!!children && !!tooltip && (

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, render } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { usePopper, Popper } from 'react-popper';
+import { usePopper } from 'react-popper';
 import Portal from '../portal/portal';
 
 export const propTypes = {
@@ -23,6 +23,8 @@ export const propTypes = {
   arrow: PropTypes.bool,
   /** Text alignment options for tooltip */
   textAlign: PropTypes.oneOf(['left', 'center', 'right']),
+  /** Position of tooltip relative to the activating element */
+  position: PropTypes.oneOf(['absolute', 'fixed', 'relative']),
 };
 
 export const defaultProps = {
@@ -33,7 +35,7 @@ export const defaultProps = {
   onClick: undefined,
   arrow: true,
   position: 'fixed',
-  inlineBlock: true,
+  textAlign: 'center',
 };
 
 /**
@@ -53,8 +55,7 @@ const TooltipHoverArea = ({
   style,
   disabled,
   position,
-  inlineBlock,
-  textAlign = 'center',
+  textAlign,
   ...popperOptions
 }) => {
   // Tooltip references
@@ -115,6 +116,7 @@ const TooltipHoverArea = ({
   // Manage tooltip visibility
   const mouseIn = () => {
     // popper.js doesn't take into account layout changes, so we need to update it manually
+    // eslint-disable-next-line
     update?.();
     !disabled && showTooltip();
   };

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { Suspense, lazy, useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { usePopper } from 'react-popper';
 
 export const propTypes = {
   /** Position of tooltip relative to the activating element */
@@ -17,6 +19,10 @@ export const propTypes = {
   style: PropTypes.shape({}),
   /** Optional, prevents tooltip from displaying when false */
   enabled: PropTypes.bool,
+  //Add popper flip option described in https://popper.js.org/popper-documentation.html#modifiers
+  flip: PropTypes.bool,
+  //Add popper arrow option described in https://popper.js.org/popper-documentation.html#modifiers
+  arrow: PropTypes.bool,
 };
 
 export const defaultProps = {
@@ -25,6 +31,8 @@ export const defaultProps = {
   style: {},
   enabled: true,
   onClick: undefined,
+  flip: true,
+  arrow: true,
 };
 
 /**
@@ -43,22 +51,108 @@ const TooltipHoverArea = ({
   onClick,
   style,
   enabled,
+  ...popperOptions
 }) => {
+  const arrowRef = useRef(null);
+  const [referenceElement, setReferenceElement] = useState(null);
+  const [popperElement, setPopperElement] = useState(null);
+
+  const popperModifiers = [
+    {
+      name: 'flip',
+      enabled: popperOptions.flip,
+    },
+    {
+      name: 'arrow',
+      enabled: popperOptions.arrow,
+      options: {
+        element: arrowRef?.current,
+        padding: 1,
+        offset: [0, 6],
+      },
+    },
+    {
+      name: 'offset',
+      options: {
+        offset: [0, 6],
+      },
+    },
+    {
+      name: 'preventOverflow',
+      options: {
+        padding: 0,
+      },
+    },
+    {
+      name: 'hide',
+      enabled: !enabled,
+    },
+  ];
+
+  const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    placement: anchor,
+    modifiers: popperModifiers,
+  });
+
+  const handleMouseEvent = event => () => {
+    if (event === 'mouseover') {
+      popperElement?.setAttribute('data-show', '');
+    } else {
+      popperElement?.removeAttribute('data-show');
+    }
+  };
+
+  const addListeners = () => {
+    ['mouseover', 'mouseout'].forEach(event => {
+      referenceElement?.addEventListener?.(
+        event,
+        handleMouseEvent(event),
+        true,
+      );
+    });
+  };
+  const removeListeners = () => {
+    ['mouseover', 'mouseout'].forEach((event, i) => {
+      referenceElement?.removeEventListener?.(
+        event,
+        handleMouseEvent(event),
+        true,
+      );
+    });
+  };
+
+  useEffect(() => {
+    addListeners();
+    return () => removeListeners();
+  }, [referenceElement]);
+
+  const root = document.getElementsByClassName('app')[0];
+
   return (
-    <span
-      aria-hidden="true"
-      className={classNames(`rc-tooltip-container`, className)}
-      onClick={onClick}
-      onKeyPress={onClick}
-      style={{ ...style }}
-    >
-      {enabled && !!children && !!tooltip && (
-        <div className={classNames('rc-tooltip', `rc-tooltip-${anchor}`)}>
-          {tooltip}
-        </div>
-      )}
-      {children}
-    </span>
+    <>
+      {!!children &&
+        !!tooltip &&
+        createPortal(
+          <div
+            className={classNames('rc-tooltip', className)}
+            ref={setPopperElement}
+            style={styles.popper}
+            {...attributes.popper}
+          >
+            {popperOptions.arrow && (
+              <span
+                className="rc-tooltip-arrow"
+                style={styles.arrow}
+                {...attributes.arrow}
+                ref={arrowRef}
+              />
+            )}
+            {tooltip}
+          </div>,
+          root,
+        )}
+      {React.cloneElement(children, { ref: setReferenceElement })}
+    </>
   );
 };
 

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -17,8 +17,8 @@ export const propTypes = {
   className: PropTypes.string,
   /** Optional additional inline style */
   style: PropTypes.shape({}),
-  /** Optional, prevents tooltip from displaying when false */
-  enabled: PropTypes.bool,
+  /** Optional, prevents tooltip from displaying when true */
+  disabled: PropTypes.bool,
   /** Show arrow on tooltip. Default is true */
   arrow: PropTypes.bool,
   /** Text alignment options for tooltip */
@@ -29,10 +29,11 @@ export const defaultProps = {
   anchor: 'top',
   className: '',
   style: {},
-  enabled: true,
+  disabled: false,
   onClick: undefined,
   arrow: true,
   position: 'fixed',
+  inlineBlock: true,
 };
 
 /**
@@ -50,8 +51,9 @@ const TooltipHoverArea = ({
   tooltip,
   onClick,
   style,
-  enabled,
+  disabled,
   position,
+  inlineBlock,
   textAlign = 'center',
   ...popperOptions
 }) => {
@@ -89,7 +91,7 @@ const TooltipHoverArea = ({
     },
     {
       name: 'hide',
-      enabled: !enabled,
+      enabled: disabled,
     },
   ];
 
@@ -114,13 +116,13 @@ const TooltipHoverArea = ({
   const mouseIn = () => {
     // popper.js doesn't take into account layout changes, so we need to update it manually
     update?.();
-    enabled && showTooltip();
+    !disabled && showTooltip();
   };
   const mouseOut = () => hideTooltip();
 
   useEffect(() => {
-    !enabled && hideTooltip();
-  }, [enabled, children, referenceElement]);
+    disabled && hideTooltip();
+  }, [disabled, children, referenceElement]);
 
   return (
     <>

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -39,14 +39,6 @@ export const defaultProps = {
   tooltip: null,
 };
 
-/**
- *
- * When elements inside a `Tooltip` are hovered over or focussed on, a tooltip will render next to it.
- *
- * @prop {string | Element } tooltip element or string to be rendered in the tooltip.
- *
- */
-
 const TooltipHoverArea = ({
   anchor,
   children,
@@ -113,8 +105,10 @@ const TooltipHoverArea = ({
   const maxWidth = typeof tooltip === 'string' ? '200px' : 'fit-content';
 
   // Manage tooltip attributes
-  const showTooltip = () => popperElement?.setAttribute('data-show', '');
-  const hideTooltip = () => popperElement?.removeAttribute('data-show');
+  const showTooltip = () =>
+    popperElement && popperElement.setAttribute('data-show', '');
+  const hideTooltip = () =>
+    popperElement && popperElement.removeAttribute('data-show');
 
   // Manage tooltip visibility
   const mouseIn = () => {

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -19,13 +19,10 @@ export const propTypes = {
   style: PropTypes.shape({}),
   /** Optional, prevents tooltip from displaying when false */
   enabled: PropTypes.bool,
-  //Add popper flip option described in https://popper.js.org/popper-documentation.html#modifiers
-  flip: PropTypes.bool,
-  //Add popper arrow option described in https://popper.js.org/popper-documentation.html#modifiers
+  /** Show arrow on tooltip. Default is true */
   arrow: PropTypes.bool,
-
-  //Positioning options for popper.js
-  position: PropTypes.oneOf(['fixed', 'absolute']),
+  /** Text alignment options for tooltip */
+  textAlign: PropTypes.oneOf(['left', 'center', 'right']),
 };
 
 export const defaultProps = {
@@ -34,7 +31,6 @@ export const defaultProps = {
   style: {},
   enabled: true,
   onClick: undefined,
-  flip: true,
   arrow: true,
   position: 'fixed',
 };
@@ -56,6 +52,7 @@ const TooltipHoverArea = ({
   style,
   enabled,
   position,
+  textAlign = 'center',
   ...popperOptions
 }) => {
   // Tooltip references
@@ -66,7 +63,7 @@ const TooltipHoverArea = ({
   const popperModifiers = [
     {
       name: 'flip',
-      enabled: popperOptions.flip,
+      enabled: true,
     },
     {
       name: 'arrow',
@@ -106,6 +103,9 @@ const TooltipHoverArea = ({
     },
   );
 
+  // only limit tooltip width when the tooltip is a string
+  const maxWidth = typeof tooltip === 'string' ? '200px' : 'fit-content';
+
   // Manage tooltip attributes
   const showTooltip = () => popperElement?.setAttribute('data-show', '');
   const hideTooltip = () => popperElement?.removeAttribute('data-show');
@@ -129,10 +129,11 @@ const TooltipHoverArea = ({
           <div
             className={classNames('rc-tooltip', className)}
             ref={setPopperElement}
-            style={{ ...styles.popper, ...style }}
+            style={{ ...styles.popper, textAlign, maxWidth, ...style }}
             {...attributes.popper}
             onMouseEnter={mouseIn}
             onMouseLeave={mouseOut}
+            onClick={onClick}
           >
             {popperOptions.arrow && (
               <span

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.js
@@ -136,6 +136,7 @@ const TooltipHoverArea = ({
             onMouseEnter={mouseIn}
             onMouseLeave={mouseOut}
             onClick={onClick}
+            role="tooltip"
           >
             {popperOptions.arrow && (
               <span
@@ -151,8 +152,11 @@ const TooltipHoverArea = ({
       )}
       <div
         ref={setReferenceElement}
+        aria-describedby={classNames('rc-tooltip', className)}
         className="rc-tooltip-reference"
         onMouseEnter={mouseIn}
+        onFocus={mouseIn}
+        onBlur={mouseOut}
         onMouseLeave={mouseOut}
       >
         {children}

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.md
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.md
@@ -50,16 +50,16 @@ const childStyle = {
 const Button = require('../button/Button.js').default;
 const { useState } = require('react');
 
-const [modalIsEnabled, setEnabled] = useState(true);
+const [modalIsDisabled, setDisabled] = useState(false);
 
 <div>
   <TooltipHoverArea
-    enabled={modalIsEnabled}
+    disabled={modalIsDisabled}
     tooltip="I'm a happy tooltip!"
     anchor="right"
   >
-    <Button onClick={() => setEnabled(!modalIsEnabled)}>
-      {`Click me to ${modalIsEnabled ? 'disable' : 'enable'} tooltip`}
+    <Button onClick={() => setDisabled(!modalIsDisabled)}>
+      {`Click me to ${modalIsDisabled ? 'disable' : 'enable'} tooltip`}
     </Button>
   </TooltipHoverArea>
 </div>;

--- a/packages/react-components/source/react/library/tooltips/TooltipHoverArea.md
+++ b/packages/react-components/source/react/library/tooltips/TooltipHoverArea.md
@@ -2,7 +2,7 @@ _Note: Aria attributes to be set on Tooltip and TooltipHoverArea components post
 
 ## Overview
 
-Use tooltips to provide instructional or contextual information beyond what fits in short descriptions. Tooltips fall under two length categories. Short tooltips are one line and their width is determined by the length of content they contain. Long tooltips have a specified width and vary in height to accommodate their content. By default, tooltips are viewed on-hover, but long tooltips have a variation where they’re invoked with a click and need to be explicitly dismissed. Use the long variation if the tooltip contains a link.
+Use tooltips to provide instructional or contextual information beyond what fits in short descriptions. By default, tooltip text is centered and will wrap if the width it exceeds 200px. If anything other than a string is passed to a tooltip, it will adjust to fit the content. Tooltips will remain open if you hover over them, allowing users to click links or interact with content.
 
 ### Microcopy
 

--- a/packages/react-components/source/react/library/tooltips/index.js
+++ b/packages/react-components/source/react/library/tooltips/index.js
@@ -1,0 +1,3 @@
+import TooltipHoverArea from './TooltipHoverArea';
+
+export default TooltipHoverArea;

--- a/packages/react-components/source/scss/library/components/_tooltips.scss
+++ b/packages/react-components/source/scss/library/components/_tooltips.scss
@@ -8,14 +8,12 @@ $puppet-tooltip-hint-elevation: 1000 !default;
 .rc-tooltip,
 .rc-tooltip[data-popper-reference-hidden] {
   @include puppet-type-small();
-
   background-color: $puppet-tooltip-hint-bg;
   border-radius: $puppet-tooltip-hint-radius;
   color: $puppet-tooltip-hint-color;
   max-width: 200px;
   opacity: 0;
   padding: $puppet-tooltip-hint-padding;
-  //pointer-events: none;
   position: absolute;
   text-align: center;
   transition: opacity, $puppet-common-transition-duration ease-in-out;
@@ -28,43 +26,54 @@ $puppet-tooltip-hint-elevation: 1000 !default;
   transition: opacity $puppet-common-transition-duration ease-in-out 0s;
   visibility: visible;
 }
+
+/* stylelint-disable-next-line */
 #rc-tooltip-arrow,
 #rc-tooltip-arrow::before {
-  position: absolute;
-  width: 6px;
-  height: 6px;
   background: inherit;
+  height: 6px;
+  position: absolute;
   text-align: initial;
+  width: 6px;
 }
 
 .rc-tooltip-reference {
   display: inline-block;
 }
 
+/* stylelint-disable-next-line */
 #rc-tooltip-arrow {
   visibility: hidden;
 }
 
+/* stylelint-disable-next-line */
 #rc-tooltip-arrow::before {
-  visibility: visible;
   content: '';
   transform: rotate(45deg);
+  visibility: visible;
 }
+
+/* stylelint-disable-next-line */
 #rc-tooltip-arrow[data-hide] {
   visibility: hidden;
 }
+
+/* stylelint-disable-next-line */
 .rc-tooltip[data-popper-placement^='top'] > #rc-tooltip-arrow {
   bottom: -3px;
 }
 
+/* stylelint-disable-next-line */
 .rc-tooltip[data-popper-placement^='bottom'] > #rc-tooltip-arrow {
   top: -3px;
 }
 
+/* stylelint-disable-next-line */
 .rc-tooltip[data-popper-placement^='left'] > #rc-tooltip-arrow {
   right: -3px;
 }
 
+/* stylelint-disable-next-line */
 .rc-tooltip[data-popper-placement^='right'] > #rc-tooltip-arrow {
   left: -3px;
 }

--- a/packages/react-components/source/scss/library/components/_tooltips.scss
+++ b/packages/react-components/source/scss/library/components/_tooltips.scss
@@ -37,7 +37,9 @@ $puppet-tooltip-hint-elevation: 1000 !default;
   background: inherit;
   text-align: initial;
 }
-
+.rc-tooltip-reference {
+  display: inline-block;
+}
 #rc-tooltip-arrow {
   visibility: hidden;
 }

--- a/packages/react-components/source/scss/library/components/_tooltips.scss
+++ b/packages/react-components/source/scss/library/components/_tooltips.scss
@@ -12,53 +12,57 @@ $puppet-tooltip-hint-elevation: 1000 !default;
   background-color: $puppet-tooltip-hint-bg;
   border-radius: $puppet-tooltip-hint-radius;
   color: $puppet-tooltip-hint-color;
+  max-width: 200px;
   opacity: 0;
   padding: $puppet-tooltip-hint-padding;
-  pointer-events: none;
+  //pointer-events: none;
   position: absolute;
+  text-align: center;
   transition: opacity, $puppet-common-transition-duration ease-in-out;
   visibility: hidden;
-  white-space: nowrap;
-  width: fit-content;
   z-index: $puppet-tooltip-hint-elevation;
+}
+.rc-tooltip-reference {
+  display: inline-block;
 }
 .rc-tooltip[data-show] {
   opacity: 1;
   transition: opacity $puppet-common-transition-duration ease-in-out 0s;
   visibility: visible;
 }
-.rc-tooltip-arrow,
-.rc-tooltip-arrow::before {
+#rc-tooltip-arrow,
+#rc-tooltip-arrow::before {
   position: absolute;
   width: 6px;
   height: 6px;
   background: inherit;
+  text-align: initial;
 }
 
-.rc-tooltip-arrow {
+#rc-tooltip-arrow {
   visibility: hidden;
 }
 
-.rc-tooltip-arrow::before {
+#rc-tooltip-arrow::before {
   visibility: visible;
   content: '';
   transform: rotate(45deg);
 }
-.rc-tooltip-arrow[data-hide] {
+#rc-tooltip-arrow[data-hide] {
   visibility: hidden;
 }
-.rc-tooltip[data-popper-placement^='top'] > .rc-tooltip-arrow {
+.rc-tooltip[data-popper-placement^='top'] > #rc-tooltip-arrow {
   bottom: -3px;
 }
 
-.rc-tooltip[data-popper-placement^='bottom'] > .rc-tooltip-arrow {
+.rc-tooltip[data-popper-placement^='bottom'] > #rc-tooltip-arrow {
   top: -3px;
 }
 
-.rc-tooltip[data-popper-placement^='left'] > .rc-tooltip-arrow {
+.rc-tooltip[data-popper-placement^='left'] > #rc-tooltip-arrow {
   right: -3px;
 }
 
-.rc-tooltip[data-popper-placement^='right'] > .rc-tooltip-arrow {
+.rc-tooltip[data-popper-placement^='right'] > #rc-tooltip-arrow {
   left: -3px;
 }

--- a/packages/react-components/source/scss/library/components/_tooltips.scss
+++ b/packages/react-components/source/scss/library/components/_tooltips.scss
@@ -21,7 +21,6 @@ $puppet-tooltip-hint-elevation: 1000 !default;
   transition: opacity, $puppet-common-transition-duration ease-in-out;
   visibility: hidden;
   z-index: $puppet-tooltip-hint-elevation;
-  width: max-content;
 }
 
 .rc-tooltip[data-show] {
@@ -37,7 +36,12 @@ $puppet-tooltip-hint-elevation: 1000 !default;
   background: inherit;
   text-align: initial;
 }
+
+// reverts to display-inline block if its not inheriting from its parent
 .rc-tooltip-reference {
+  display: revert;
+}
+.rc-tooltip-reference div {
   display: inline-block;
 }
 #rc-tooltip-arrow {

--- a/packages/react-components/source/scss/library/components/_tooltips.scss
+++ b/packages/react-components/source/scss/library/components/_tooltips.scss
@@ -21,10 +21,9 @@ $puppet-tooltip-hint-elevation: 1000 !default;
   transition: opacity, $puppet-common-transition-duration ease-in-out;
   visibility: hidden;
   z-index: $puppet-tooltip-hint-elevation;
+  width: max-content;
 }
-.rc-tooltip-reference {
-  display: inline-block;
-}
+
 .rc-tooltip[data-show] {
   opacity: 1;
   transition: opacity $puppet-common-transition-duration ease-in-out 0s;

--- a/packages/react-components/source/scss/library/components/_tooltips.scss
+++ b/packages/react-components/source/scss/library/components/_tooltips.scss
@@ -37,13 +37,10 @@ $puppet-tooltip-hint-elevation: 1000 !default;
   text-align: initial;
 }
 
-// reverts to display-inline block if its not inheriting from its parent
 .rc-tooltip-reference {
-  display: revert;
-}
-.rc-tooltip-reference div {
   display: inline-block;
 }
+
 #rc-tooltip-arrow {
   visibility: hidden;
 }

--- a/packages/react-components/source/scss/library/components/_tooltips.scss
+++ b/packages/react-components/source/scss/library/components/_tooltips.scss
@@ -4,17 +4,9 @@ $puppet-tooltip-hint-padding: $puppet-common-spacing-base
   $puppet-common-spacing-base * 2 !default;
 $puppet-tooltip-hint-radius: $puppet-common-border-radius !default;
 $puppet-tooltip-hint-elevation: 1000 !default;
-$puppet-tooltip-caret-total-width: 6px;
-$puppet-tooltip-caret-visible-width: 3px;
-$puppet-caret-offset: 11.5px;
-$puppet-caret-vertical-offset: calc(100% + #{$puppet-tooltip-caret-total-width});
 
-.rc-tooltip-container {
-  display: inline-block;
-  position: relative;
-}
-
-.rc-tooltip {
+.rc-tooltip,
+.rc-tooltip[data-popper-reference-hidden] {
   @include puppet-type-small();
 
   background-color: $puppet-tooltip-hint-bg;
@@ -22,6 +14,7 @@ $puppet-caret-vertical-offset: calc(100% + #{$puppet-tooltip-caret-total-width})
   color: $puppet-tooltip-hint-color;
   opacity: 0;
   padding: $puppet-tooltip-hint-padding;
+  pointer-events: none;
   position: absolute;
   transition: opacity, $puppet-common-transition-duration ease-in-out;
   visibility: hidden;
@@ -29,79 +22,43 @@ $puppet-caret-vertical-offset: calc(100% + #{$puppet-tooltip-caret-total-width})
   width: fit-content;
   z-index: $puppet-tooltip-hint-elevation;
 }
-
-.rc-tooltip-container:hover .rc-tooltip {
+.rc-tooltip[data-show] {
   opacity: 1;
   transition: opacity $puppet-common-transition-duration ease-in-out 0s;
   visibility: visible;
 }
-
-/* TOOLTIP POSITIONS */
-.rc-tooltip-top {
-  left: 50%;
-  top: 0;
-  transform: translate(-50%, calc(-100% - #{$puppet-tooltip-caret-total-width}));
-}
-
-.rc-tooltip-bottom {
-  bottom: 0;
-  left: 50%;
-  transform: translate(-50%, $puppet-caret-vertical-offset);
-}
-
-.rc-tooltip-right {
-  right: 0.5px;
-  top: 50%;
-  transform: translate(calc(100% + #{$puppet-tooltip-caret-total-width}), -50%);
-}
-
-.rc-tooltip-left {
-  left: 0.5px;
-  top: 50%;
-  transform: translate(calc(-100% - #{$puppet-tooltip-caret-total-width}), -50%);
-}
-
-/* CARETS */
-.rc-tooltip-top::after {
-  border: $puppet-tooltip-caret-total-width solid rgba($puppet-black, 0.9);
-  border-color: rgba($puppet-black, 0.9) transparent transparent transparent;
-  bottom: -$puppet-caret-offset;
-  content: '';
-  display: block;
-  left: 50%;
+.rc-tooltip-arrow,
+.rc-tooltip-arrow::before {
   position: absolute;
-  transform: translateX(-50%);
+  width: 6px;
+  height: 6px;
+  background: inherit;
 }
 
-.rc-tooltip-right::after {
-  border: $puppet-tooltip-caret-total-width solid rgba($puppet-black, 0.9);
-  border-color: transparent rgba($puppet-black, 0.9) transparent transparent;
-  content: '';
-  display: block;
-  left: 0.5px;
-  position: absolute;
-  top: 50%;
-  transform: translate(-#{$puppet-caret-offset}, -50%);
+.rc-tooltip-arrow {
+  visibility: hidden;
 }
 
-.rc-tooltip-bottom::after {
-  border: $puppet-tooltip-caret-total-width solid rgba($puppet-black, 0.9);
-  border-color: transparent transparent rgba($puppet-black, 0.9) transparent;
+.rc-tooltip-arrow::before {
+  visibility: visible;
   content: '';
-  display: block;
-  left: 50%;
-  position: absolute;
-  top: -$puppet-caret-offset;
-  transform: translateX(-50%);
+  transform: rotate(45deg);
+}
+.rc-tooltip-arrow[data-hide] {
+  visibility: hidden;
+}
+.rc-tooltip[data-popper-placement^='top'] > .rc-tooltip-arrow {
+  bottom: -3px;
 }
 
-.rc-tooltip-left::after {
-  border: $puppet-tooltip-caret-total-width solid rgba($puppet-black, 0.9);
-  border-color: transparent transparent transparent rgba($puppet-black, 0.9);
-  content: '';
-  display: block;
-  position: absolute;
-  right: 0.5px; //shows small white gap when set to zero
-  top: 50%;
-  transform: translate($puppet-caret-offset, -50%);
+.rc-tooltip[data-popper-placement^='bottom'] > .rc-tooltip-arrow {
+  top: -3px;
+}
+
+.rc-tooltip[data-popper-placement^='left'] > .rc-tooltip-arrow {
+  right: -3px;
+}
+
+.rc-tooltip[data-popper-placement^='right'] > .rc-tooltip-arrow {
+  left: -3px;
 }

--- a/packages/react-components/test/form/FormSection.js
+++ b/packages/react-components/test/form/FormSection.js
@@ -1,10 +1,26 @@
 import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 import React from 'react';
+import sinon from 'sinon';
+import ReactDOM from 'react-dom';
 
 import FormSection from '../../source/react/library/form/FormSection';
 
+let sandbox;
+let mockTooltip;
+
 describe('<FormSection />', () => {
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    mockTooltip = sandbox
+      .stub(ReactDOM, 'createPortal')
+      .callsFake(portal => portal);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   it('should render without blowing up', () => {
     const wrapper = shallow(<FormSection />);
 

--- a/packages/react-components/test/tooltip/tooltipHoverArea.js
+++ b/packages/react-components/test/tooltip/tooltipHoverArea.js
@@ -2,11 +2,29 @@ import jsdom from 'mocha-jsdom';
 import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 import React from 'react';
+import ReactDOM from 'react-dom';
+import sinon from 'sinon';
 
 import TooltipHoverArea from '../../source/react/library/tooltips/TooltipHoverArea';
 
+let sandbox;
+let mockTooltip;
+
 describe('<TooltipHoverArea />', () => {
   jsdom({ skipWindowCheck: true });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    // Spy on createPortal to render within test, without root div
+    mockTooltip = sandbox
+      .stub(ReactDOM, 'createPortal')
+      .callsFake(portal => portal);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
 
   const defaultProps = {
     tooltip: <span className="tooltip">I'm the tooltip</span>,
@@ -16,14 +34,8 @@ describe('<TooltipHoverArea />', () => {
   it('should render wrapper around children by default', () => {
     const wrapper = shallow(<TooltipHoverArea {...defaultProps} />);
 
-    expect(wrapper.find('.rc-tooltip-container')).to.have.length(1);
+    expect(wrapper.find('.rc-tooltip-reference')).to.have.length(1);
     expect(wrapper.find('.rc-tooltip')).to.have.length(1);
-  });
-
-  it('should not wrap children when enabled is false', () => {
-    const wrapper = mount(<TooltipHoverArea {...defaultProps} disabled />);
-
-    expect(wrapper.find('.rc-tooltip-container')).to.have.length(1);
-    expect(wrapper.find('.rc-tooltip')).to.have.length(0);
+    expect(wrapper.find('.rc-tooltip').text()).to.eql("I'm the tooltip");
   });
 });

--- a/packages/react-components/test/tooltip/tooltipHoverArea.js
+++ b/packages/react-components/test/tooltip/tooltipHoverArea.js
@@ -21,9 +21,7 @@ describe('<TooltipHoverArea />', () => {
   });
 
   it('should not wrap children when enabled is false', () => {
-    const wrapper = mount(
-      <TooltipHoverArea {...defaultProps} enabled={false} />,
-    );
+    const wrapper = mount(<TooltipHoverArea {...defaultProps} disabled />);
 
     expect(wrapper.find('.rc-tooltip-container')).to.have.length(1);
     expect(wrapper.find('.rc-tooltip')).to.have.length(0);


### PR DESCRIPTION
Changes to TooltipHoverArea:
- Use popper.js library to display tooltip
- Use a portal to display tooltip on the 'root' node at the top of the DOM to prevent it getting cut off
- Add centering and multi-line options to tooltip text
- Update docs
