### PR TITLE
(CDPE-4655) Add tooltip to Sidebar.Footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## react-components 5.33.1 (2022-03-04)
+
+- [SidebarFooter] Add tooltip option (by [@chrisleicester](https://github.com/chrisleicester) in [#552](https://github.com/puppetlabs/design-system/pull/552))
+
 ## react-components 5.33.0 (2022-02-28)
 
 - [Breadcrumb] Add Back type (by [@Lukeaber](https://github.com/Lukeaber) in [#549](https://github.com/puppetlabs/design-system/pull/549))
@@ -5,6 +9,7 @@
 ## react-components 5.32.5 (2022-02-24)
 
 - [Icon] Add change and change warning icon
+
 ## react-components 5.32.4 (2022-02-11)
 
 - [Icon] Add exception icon

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.33.0",
+  "version": "5.33.1",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/react/library/sidebar/Sidebar.md
+++ b/packages/react-components/source/react/library/sidebar/Sidebar.md
@@ -68,7 +68,7 @@ import Badge from '../badge';
       onClick={console.log}
       enableSignout
       onSignout={console.log}
-      tooltip="Sign out!"
+      signoutTooltip="This is a custom tooltip"
     />
   </Sidebar>
 </div>;

--- a/packages/react-components/source/react/library/sidebar/Sidebar.md
+++ b/packages/react-components/source/react/library/sidebar/Sidebar.md
@@ -68,6 +68,7 @@ import Badge from '../badge';
       onClick={console.log}
       enableSignout
       onSignout={console.log}
+      tooltip="Sign out!"
     />
   </Sidebar>
 </div>;

--- a/packages/react-components/source/react/library/sidebar/SidebarFooter.js
+++ b/packages/react-components/source/react/library/sidebar/SidebarFooter.js
@@ -22,7 +22,7 @@ const propTypes = {
   /** Boolean flag to enable or disable (default) signout button */
   enableSignout: PropTypes.bool,
   /** Sign-out icon tooltip text */
-  tooltip: PropTypes.string,
+  signoutTooltip: PropTypes.string,
   /** Signout callback function */
   onSignout: PropTypes.func,
 };
@@ -34,7 +34,7 @@ const defaultProps = {
   minimized: false,
   profileIcon: null,
   enableSignout: false,
-  tooltip: null,
+  signoutTooltip: 'Sign out',
   onSignout: () => {},
 };
 
@@ -45,7 +45,7 @@ const SidebarFooter = ({
   minimized,
   profileIcon: profileIconProp,
   enableSignout,
-  tooltip,
+  signoutTooltip,
   onSignout,
   ...rest
 }) => {
@@ -70,20 +70,15 @@ const SidebarFooter = ({
 
     if (enableSignout) {
       signout = (
-        <Button
-          className="rc-sidebar-footer-button-signout"
-          onClick={onSignout}
-        >
-          <Icon type="sign-out" className="rc-sidebar-footer-signout-icon" />
-        </Button>
+        <TooltipHoverArea anchor="top" tooltip={signoutTooltip}>
+          <Button
+            className="rc-sidebar-footer-button-signout"
+            onClick={onSignout}
+          >
+            <Icon type="sign-out" className="rc-sidebar-footer-signout-icon" />
+          </Button>
+        </TooltipHoverArea>
       );
-      if (tooltip) {
-        signout = (
-          <TooltipHoverArea anchor="top" tooltip={tooltip}>
-            {signout}
-          </TooltipHoverArea>
-        );
-      }
     }
   }
 

--- a/packages/react-components/source/react/library/sidebar/SidebarFooter.js
+++ b/packages/react-components/source/react/library/sidebar/SidebarFooter.js
@@ -6,6 +6,7 @@ import Heading from '../heading';
 import Text from '../text';
 import Avatar from '../avatar';
 import Button from '../button';
+import TooltipHoverArea from '../tooltips/TooltipHoverArea';
 
 const propTypes = {
   /** The root HTML element  */
@@ -20,6 +21,8 @@ const propTypes = {
   profileIcon: PropTypes.node,
   /** Boolean flag to enable or disable (default) signout button */
   enableSignout: PropTypes.bool,
+  /** Sign-out icon tooltip text */
+  tooltip: PropTypes.string,
   /** Signout callback function */
   onSignout: PropTypes.func,
 };
@@ -31,6 +34,7 @@ const defaultProps = {
   minimized: false,
   profileIcon: null,
   enableSignout: false,
+  tooltip: null,
   onSignout: () => {},
 };
 
@@ -41,6 +45,7 @@ const SidebarFooter = ({
   minimized,
   profileIcon: profileIconProp,
   enableSignout,
+  tooltip,
   onSignout,
   ...rest
 }) => {
@@ -72,6 +77,13 @@ const SidebarFooter = ({
           <Icon type="sign-out" className="rc-sidebar-footer-signout-icon" />
         </Button>
       );
+      if (tooltip) {
+        signout = (
+          <TooltipHoverArea anchor="top" tooltip={tooltip}>
+            {signout}
+          </TooltipHoverArea>
+        );
+      }
     }
   }
 

--- a/packages/react-components/test/sidebar/Sidebar.js
+++ b/packages/react-components/test/sidebar/Sidebar.js
@@ -130,5 +130,36 @@ describe('<Sidebar />', () => {
       wrapper.find('.rc-sidebar-footer-button-signout').simulate('click');
       expect(callback.calledOnce).to.be.true;
     });
+
+    it('should not render tooltip when no tooltip is specified', () => {
+      const callback = sinon.fake();
+      const wrapper = shallow(
+        <Sidebar.Footer enableSignout onSignout={callback} />,
+      );
+
+      expect(wrapper.find('TooltipHoverArea').length).to.eql(0);
+    });
+
+    it('should not render tooltip when sigout is disabled', () => {
+      const callback = sinon.fake();
+      const wrapper = shallow(
+        <Sidebar.Footer tooltip="I love being a tooltip" />,
+      );
+
+      expect(wrapper.find('TooltipHoverArea').length).to.eql(0);
+    });
+
+    it('should render a tooltip with signout is enabled and tooltip is specified', () => {
+      const callback = sinon.fake();
+      const wrapper = shallow(
+        <Sidebar.Footer
+          enableSignout
+          onSignout={callback}
+          tooltip="I love being a tooltip"
+        />,
+      );
+
+      expect(wrapper.find('TooltipHoverArea').length).to.eql(1);
+    });
   });
 });

--- a/packages/react-components/test/sidebar/Sidebar.js
+++ b/packages/react-components/test/sidebar/Sidebar.js
@@ -131,15 +131,6 @@ describe('<Sidebar />', () => {
       expect(callback.calledOnce).to.be.true;
     });
 
-    it('should not render tooltip when no tooltip is specified', () => {
-      const callback = sinon.fake();
-      const wrapper = shallow(
-        <Sidebar.Footer enableSignout onSignout={callback} />,
-      );
-
-      expect(wrapper.find('TooltipHoverArea').length).to.eql(0);
-    });
-
     it('should not render tooltip when sigout is disabled', () => {
       const callback = sinon.fake();
       const wrapper = shallow(
@@ -149,17 +140,29 @@ describe('<Sidebar />', () => {
       expect(wrapper.find('TooltipHoverArea').length).to.eql(0);
     });
 
-    it('should render a tooltip with signout is enabled and tooltip is specified', () => {
+    it('should render the default tooltip when no tooltip is specified', () => {
+      const callback = sinon.fake();
+      const wrapper = shallow(
+        <Sidebar.Footer enableSignout onSignout={callback} />,
+      );
+      expect(wrapper.find('TooltipHoverArea').prop('tooltip')).to.eql(
+        'Sign out',
+      );
+    });
+
+    it('should render a a custom tooltip when specified', () => {
       const callback = sinon.fake();
       const wrapper = shallow(
         <Sidebar.Footer
           enableSignout
           onSignout={callback}
-          tooltip="I love being a tooltip"
+          signoutTooltip="I love being a tooltip"
         />,
       );
 
-      expect(wrapper.find('TooltipHoverArea').length).to.eql(1);
+      expect(wrapper.find('TooltipHoverArea').prop('tooltip')).to.eql(
+        'I love being a tooltip',
+      );
     });
   });
 });


### PR DESCRIPTION
Prior to this commit, if the Sidebar Footer was used and the sign-out
button was present, there was no way to add a tooltip to explain the
usage of this button. This makes it difficult for someone using a screen
reader to find this button and use it.

With this commit, we add an optional parameter to the Sidebar Footer to
specify tooltip text. If specified, the tooltip will appear above the
sign-out button when hovered over.

### Screenshot of proposed changes

<img width="268" alt="Screen Shot 2022-03-04 at 4 40 55 PM" src="https://user-images.githubusercontent.com/8687939/156859896-3e5e5742-ed5f-4444-86e7-b64f1648165c.png">

