### PR TITLE
Add className prop to confirmation modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## react-components 5.33.1 (2022-03-10)
+
+- [ConfirmationModal] Add className prop to confirmation modal (by [@Lukeaber](https://github.com/Lukeaber) in [#555](https://github.com/puppetlabs/design-system/pull/555))
 ## react-components 5.33.2 (2022-03-09)
 
 - [Icon] Add Play icon

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.33.2",
+  "version": "5.33.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppet/react-components",
-      "version": "5.33.2",
+      "version": "5.33.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@popperjs/core": "^2.9.2",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.33.2",
+  "version": "5.33.3",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/react/library/confirmation-modal/ConfirmationModal.js
+++ b/packages/react-components/source/react/library/confirmation-modal/ConfirmationModal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import Modal from '../modal';
 import Button from '../button';
 
@@ -24,6 +25,8 @@ const propTypes = {
   onCancel: PropTypes.func,
   /** If true, confirm button will render with a loading spinner */
   confirmButtonLoading: PropTypes.bool,
+  /** Additional classes to add in addition to 'rc-modal' */
+  className: PropTypes.string,
 };
 const defaultProps = {
   title: '',
@@ -36,6 +39,7 @@ const defaultProps = {
   onConfirm: () => {},
   onCancel: () => {},
   confirmButtonLoading: false,
+  className: '',
 };
 
 const ConfirmationModal = ({
@@ -49,8 +53,13 @@ const ConfirmationModal = ({
   onConfirm,
   onCancel,
   confirmButtonLoading,
+  className,
 }) => (
-  <Modal onClose={onCancel} isOpen={isOpen}>
+  <Modal
+    className={classnames('rc-confirmation-modal', className)}
+    onClose={onCancel}
+    isOpen={isOpen}
+  >
     {title && <Modal.Title>{title}</Modal.Title>}
     {description}
     <Modal.Actions>


### PR DESCRIPTION
### Description of proposed changes
Currently we cannot pass classnames to the confirmation modal, this is a bit of an issue as the modal renders separate from the rest of a pages html therefore we cannot change the'rc-modal' classname without risking global css changes

### Screenshot of proposed changes
<img width="660" alt="Screenshot 2022-03-10 at 09 16 52" src="https://user-images.githubusercontent.com/30826846/157630820-4f78d097-937e-409b-9c98-924c0ae9f685.png">
<img width="290" alt="Screenshot 2022-03-10 at 09 17 02" src="https://user-images.githubusercontent.com/30826846/157630836-cfc342af-b499-46e5-a9b2-081051292a6e.png">

