### PR TITLE
Add Action Buttons on the table header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## data-grid 0.6.5 (2022-04-11)
+
+- [Table] Add Action Buttons on the data-grid Table header (by [@comfucios](https://github.com/comfucios) in [#565](https://github.com/puppetlabs/design-system/pull/565))
+
 ## data-grid 0.6.5 (2022-03-29)
 
 - [Table] Add `fixedLastColumn` option to data-grid Table (by [@vine77](https://github.com/vine77) in [#559](https://github.com/puppetlabs/design-system/pull/559))

--- a/packages/data-grid/package-lock.json
+++ b/packages/data-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@puppet/data-grid",
-	"version": "0.6.5",
+	"version": "0.6.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/data-grid/package.json
+++ b/packages/data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/data-grid",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/packages/data-grid/src/tableHeader/TableHeader.jsx
+++ b/packages/data-grid/src/tableHeader/TableHeader.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
-import { string, arrayOf, shape, node, func, bool } from 'prop-types';
-import { Text, Input, ButtonSelect, Badge } from '@puppet/react-components';
+import { string, arrayOf, shape, node, func, bool, oneOf } from 'prop-types';
+import {
+  Text,
+  Input,
+  Button,
+  ButtonSelect,
+  Badge,
+} from '@puppet/react-components';
 import QuickFilter from '../quickFilter';
 import TagBuilder from '../tagBuilder';
 import './TableHeader.scss';
@@ -69,6 +75,29 @@ const propTypes = {
   actionLabel: string,
   /** Callback function called when an action is selected from the dropdown list */
   onActionSelect: func,
+  /** Allows you to pass an array of Action buttons */
+  actionButtons: arrayOf(
+    /** Action button next to actions ( if visible ) to trigger an general action to the table. */
+    shape({
+      /** Text which will be displayed button  */
+      label: string.isRequired,
+      /** Optional icon to be rendered instead of / in addition to button text. */
+      icon: string,
+      /** Button visual variant */
+      type: oneOf([
+        'primary',
+        'secondary',
+        'tertiary',
+        'danger',
+        'transparent',
+        'text',
+      ]),
+      /** Callback function called when the button is clicked */
+      onClick: func.isRequired,
+      /** Loading status of the action */
+      loading: bool,
+    }),
+  ),
   /** Boolean used to conditionally render the showSelectAllBadge */
   showSelectAllBadge: bool,
   /** Text shown in the selectAllBadge */
@@ -99,6 +128,7 @@ const defaultProps = {
   actions: [],
   actionLabel: 'Actions',
   onActionSelect: () => {},
+  actionButtons: [],
   showSelectAllBadge: false,
   selectAllBadgeText: 'Select all *** nodes',
   onSelectAllBadgeClick: () => {},
@@ -123,6 +153,7 @@ function TableHeader({
   actions,
   actionLabel,
   onActionSelect,
+  actionButtons,
   showSelectAllBadge,
   selectAllBadgeText,
   onSelectAllBadgeClick,
@@ -153,16 +184,34 @@ function TableHeader({
             <QuickFilter filters={filters} onFilterSelect={onFilterChange} />
           </div>
         )}
-        {actions.length > 0 ? (
-          <ButtonSelect
-            className="dg-table-action"
-            type="transparent"
-            options={actions}
-            placeholder={actionLabel}
-            anchor="bottom right"
-            onChange={value => onActionSelect(value)}
-          />
-        ) : null}
+        <div className="dg-table-header-actions">
+          {actions.length > 0 ? (
+            <ButtonSelect
+              className="dg-table-action"
+              type="transparent"
+              options={actions}
+              placeholder={actionLabel}
+              anchor="bottom right"
+              onChange={value => onActionSelect(value)}
+            />
+          ) : null}
+          {actionButtons.length > 0 &&
+            actionButtons.map(actionButton => {
+              return typeof actionButton.onClick === 'function' &&
+                actionButton.label !== '' ? (
+                <Button
+                  className="dg-table-action"
+                  icon={actionButton.icon}
+                  onClick={actionButton.onClick}
+                  type={actionButton.type}
+                  loading={actionButton.loading}
+                  key={actionButton.label}
+                >
+                  {actionButton.label}
+                </Button>
+              ) : null;
+            })}
+        </div>
       </div>
       {activeFilters.length > 0 && (
         <TagBuilder

--- a/packages/data-grid/src/tableHeader/TableHeader.md
+++ b/packages/data-grid/src/tableHeader/TableHeader.md
@@ -518,10 +518,11 @@ class StatefulParent extends React.Component {
 
 ### Table Actions
 
-Table actions are a list of actionable commands with are applied to the selected rows within a table. It is expected that table actions only work with selectable tables. 
+Table actions are a list of actionable commands with are applied to the selected rows within a table. It is expected that table actions only work with selectable tables.
 
 ```jsx
 const onActionClick = filters => {
+
   console.log('An action was selected', filters);
 };
 
@@ -547,4 +548,52 @@ const actions = [
   actions={actions}
   onActionSelect={onActionClick}
 />;
+```
+
+### Table Action Buttons
+
+Table action buttons are buttons that will trigger an action on the dataset. An example of a dataset action is `export`
+
+```jsx
+  class TableHeaderActionButton extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        exportLoading: false,
+        scanLoading: false,
+      }
+    }
+
+    onActionButtonClick(button) {
+      this.setState({ [`${button}Loading`]: true});
+      console.log(`Action ${button} was triggered` );
+      setTimeout(()=>{
+        console.log(`Action ${button} finished`)
+        this.setState({ [`${button}Loading`]: false});
+      }, 2000);
+    }
+
+    render() {
+      const { exportLoading, scanLoading } = this.state;
+      return (
+        <TableHeader
+          actionButtons={[{
+            label: 'export',
+            onClick: () => this.onActionButtonClick('export'),
+            loading: exportLoading,
+            icon: 'export',
+          },{
+            label: 'scan',
+            type: 'transparent',
+            onClick: () => this.onActionButtonClick('scan'),
+            loading: scanLoading,
+            icon: 'scan',
+          },
+          ]}
+        />
+      );
+    }
+  }
+
+<TableHeaderActionButton />;
 ```

--- a/packages/data-grid/src/tableHeader/TableHeader.scss
+++ b/packages/data-grid/src/tableHeader/TableHeader.scss
@@ -6,6 +6,14 @@
   display: flex;
   padding-bottom: 16px;
 
+  .dg-table-header-actions {
+    display: flex;
+    margin-left: auto;
+    .dg-table-action {
+      margin-right: 8px;
+    }
+  }
+
   .dg-table-header-search {
     max-width: 360px;
   }
@@ -25,9 +33,6 @@
     margin-bottom: 8px;
   }
 
-  .dg-table-action {
-    margin-left: auto;
-  }
 }
 
 .dg-table-header-text-container{


### PR DESCRIPTION
### Description of proposed changes
Adding optional action buttons to the top right of the table for actions or things that are different than the `selectable` table dropdown actions 


### Screenshot of proposed changes
<img width="832" alt="image (7)" src="https://user-images.githubusercontent.com/32846251/162487789-68d2bdbe-51e0-482f-8349-82294d4bb51a.png">
<img width="821" alt="image (6)" src="https://user-images.githubusercontent.com/32846251/162487795-1e227760-0a30-4d42-bbfd-e27681805de2.png">

![ActionButton](https://user-images.githubusercontent.com/32846251/162487784-01783af4-7718-49be-90b5-fa29164e9e0f.gif)
