### PR TITLE
(maint) Remove unused data-grid 'sb' dep to remediate vulnerable transitive dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## data-grid 0.6.8
+
+- Removed unused 'sb' dependency because it contained a vulnerability caught by our security scanner. https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827
+
 ## data-grid 0.6.7 (2022-04-13)
 
 - [Table] Ability to disable a row's checkbox on selectable table (by [@comfucios](https://github.com/comfucios) in [#570](https://github.com/puppetlabs/design-system/pull/570))

--- a/packages/data-grid/package-lock.json
+++ b/packages/data-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@puppet/data-grid",
-	"version": "0.6.7",
+	"version": "0.6.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5302,11 +5302,6 @@
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
-		"async": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-		},
 		"async-each": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -6035,11 +6030,6 @@
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
-		},
-		"bignumber.js": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
 		},
 		"binary-extensions": {
 			"version": "2.1.0",
@@ -6997,7 +6987,8 @@
 		"commander": {
 			"version": "2.20.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
-			"integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg=="
+			"integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -7277,7 +7268,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cosmiconfig": {
 			"version": "5.2.1",
@@ -11359,7 +11351,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -11828,7 +11821,8 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -14374,17 +14368,6 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
-		"mysql": {
-			"version": "2.17.1",
-			"resolved": "https://registry.npmjs.org/mysql/-/mysql-2.17.1.tgz",
-			"integrity": "sha512-7vMqHQ673SAk5C8fOzTG2LpPcf3bNt0oL3sFpxPEEFp1mdlDcrLK0On7z8ZYKaaHrHwNcQ/MTUz7/oobZ2OyyA==",
-			"requires": {
-				"bignumber.js": "7.2.1",
-				"readable-stream": "2.3.6",
-				"safe-buffer": "5.1.2",
-				"sqlstring": "2.3.1"
-			}
-		},
 		"namor": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/namor/-/namor-1.1.3.tgz",
@@ -15934,7 +15917,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -16388,6 +16372,7 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -17037,7 +17022,8 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -17462,16 +17448,6 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
-		},
-		"sb": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/sb/-/sb-0.2.1.tgz",
-			"integrity": "sha1-X5hWrKM++XfGV2LUNUrD9+Cagiw=",
-			"requires": {
-				"async": "^0.9.0",
-				"commander": "^2.3.0",
-				"mysql": "^2.4.2"
-			}
 		},
 		"scheduler": {
 			"version": "0.19.1",
@@ -18013,11 +17989,6 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"sqlstring": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-			"integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
-		},
 		"sshpk": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -18486,6 +18457,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -19800,7 +19772,8 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"util.promisify": {
 			"version": "1.0.0",

--- a/packages/data-grid/package.json
+++ b/packages/data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/data-grid",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "dist/index.js",
@@ -31,8 +31,7 @@
     "init": "^0.1.2",
     "lodash": "^4.17.20",
     "namor": "^1.1.2",
-    "prop-types": "^15.7.2",
-    "sb": "^0.2.1"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.11.4",


### PR DESCRIPTION
- The security scan in the CD4PE pipeline was failing due to a vulnerability in a transitive dependency of the data-grid package.
- The package has been removed because it appears to be unused.

