### PR TITLE
Add `circle-empty` icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## data-grid 0.6.10 (2022-07-08)
+
+- Allow React 18 as a peer dependency (by [@mardotio](https://github.com/mardotio) in [#583](https://github.com/puppetlabs/design-system/pull/583))
+
+## react-components 5.33.8 (2022-07-08)
+
+- Add `circle-empty` icon (by [@mardotio](https://github.com/mardotio) in [#583](https://github.com/puppetlabs/design-system/pull/583))
+- Allow React 18 as a peer dependency (by [@mardotio](https://github.com/mardotio) in [#583](https://github.com/puppetlabs/design-system/pull/583))
+
+## data-layouts 2.0.0-alpha.9 (2022-07-08)
+
+- Allow React 18 as a peer dependency (by [@mardotio](https://github.com/mardotio) in [#583](https://github.com/puppetlabs/design-system/pull/583))
+
 ## react-components 5.33.7 (2022-05-18)
 
 - [Icon] Add "folder" icon (by [@vine77](https://github.com/vine77) in [#574](https://github.com/puppetlabs/design-system/pull/574))

--- a/packages/data-grid/package-lock.json
+++ b/packages/data-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@puppet/data-grid",
-	"version": "0.6.9",
+	"version": "0.6.10",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/data-grid/package.json
+++ b/packages/data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/data-grid",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "dist/index.js",
@@ -21,8 +21,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^16.13.0 || ^17.0.0",
-    "react-dom": "^16.13.0 || ^17.0.0"
+    "react": "^16.13.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.13.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@puppet/react-components": "^5.25.1",

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.33.7",
+  "version": "5.33.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.33.7",
+  "version": "5.33.8",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^16.13.0 || ^17.0.0",
-    "react-dom": "^16.13.0 || ^17.0.0"
+    "react": "^16.13.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.13.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.4",

--- a/packages/react-components/source/react/library/icon/icons.js
+++ b/packages/react-components/source/react/library/icon/icons.js
@@ -336,6 +336,16 @@ const icons = {
     ),
   },
 
+  'circle-empty': {
+    medium: (
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 0c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8Zm0 14c3.309 0 6-2.691 6-6s-2.691-6-6-6-6 2.691-6 6 2.691 6 6 6Z"
+      />
+    ),
+  },
+
   clipboard: {
     large: (
       <path

--- a/packages/react-layouts/package-lock.json
+++ b/packages/react-layouts/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@puppet/react-layouts",
-	"version": "2.0.0-alpha.8",
+	"version": "2.0.0-alpha.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-layouts/package.json
+++ b/packages/react-layouts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-layouts",
-  "version": "2.0.0-alpha.8",
+  "version": "2.0.0-alpha.9",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "dist/react-layouts.js",
@@ -22,8 +22,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@puppet/react-components": "^5.22.0",


### PR DESCRIPTION
### Description of proposed changes
- Add new `circle-empty` icon to react-components
- Add React 18 to peer dependencies for react-components, data-grid and react-layouts


### Screenshot of proposed changes

<img width="711" alt="Screen Shot 2022-07-08 at 9 32 28 AM" src="https://user-images.githubusercontent.com/25378324/178002139-a8802e7d-4b7b-4ff4-a7e5-921d78cb90cf.png">

