### PR TITLE
(maint) Remove PAT from deploy worflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,5 @@ jobs:
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:
-        token: ${{ secrets.ACCESS_TOKEN }}
         branch: gh-pages
         folder: packages/design-system-website/dist


### PR DESCRIPTION
The existing PAT was no longer valid which was causing the deploy action
to fail. Instead of creating a new PAT, I removed the token from the
deploy action since the default value is the token scoped to the current
repo.

