### PR TITLE
(CDPE-6560) Add publish github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish packages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 12.4.0
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set Node version
+        uses: actions/setup-node@v4
+        with:
+          node-version: 12.4.0
+      - name: Install all package dependencies
+        run: npm install
+      - name: Publish packages
+        run: npm run publish


### PR DESCRIPTION
### Description of proposed changes

Add a new publish github action that will run the tests and publish all packages using lerna on merge to main or when run manually. This will only publish packages that have a newer version than what is already published to the registry.

### Screenshot of proposed changes

