### PR TITLE
(CDPE-6560) Update publish github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Install all package dependencies
         run: npm install
       - name: Publish packages
-        run: npm run publish
+        run: npm run release


### PR DESCRIPTION
### Description of proposed changes

Github action was originally trying to call an old release script here `/scripts/publish.sh`. The intention here should be to call the npm script `release` instead. We can probably remove that old script but for now this will just fix the npm call in the github action.

### Screenshot of proposed changes

