### PR TITLE
(CDPE-6560) Use new npm access token for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,17 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set Node version
         uses: actions/setup-node@v4
+        with:
+          node-version: 12.4.0
+          registry-url: https://registry.npmjs.org
       - name: Install all package dependencies
         run: npm install
       - name: Publish packages
-        run: npm run release
+        run: npm run publish


### PR DESCRIPTION
### Description of proposed changes

Update publish github action to use new NPM_AUTH_TOKEN secret.

### Screenshot of proposed changes

