### PR TITLE
(CDPE-6575) - update logo viewBox size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## react-components 5.34.5 (2024-03-25)
+
+- [Logo] Bug fixing continuous delivery logo viewBox size (by [@danadoherty639](https://github.com/danadoherty639))
+
 ## react-components 5.34.4 (2024-03-19)
 
 - [Logo] Add continuous delivery logo (by [@mttsltrs](https://github.com/mttsltrs))

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.34.4",
+  "version": "5.34.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2490,11 +2490,6 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
       "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
-    },
-    "@puppet/sass-variables": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@puppet/sass-variables/-/sass-variables-1.4.4.tgz",
-      "integrity": "sha512-yaXg5PmfWQYbGOO6CgYDDy0MGuhVSZchyF4+Ona4YfGgbFfTTT6aKAf/qK9dkMaylXHYnpbO/SWBWhv6y1eQgQ=="
     },
     "@sinonjs/commons": {
       "version": "1.6.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.34.4",
+  "version": "5.34.5",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/react/library/logo/logos.js
+++ b/packages/react-components/source/react/library/logo/logos.js
@@ -396,7 +396,7 @@ const securityComplianceManagement = () => ({
 });
 
 const continuousDelivery = () => ({
-  viewBox: '0 0 101 33',
+  viewBox: '0 0 170 40',
   svg: (
     <>
       <path


### PR DESCRIPTION
Update the viewBox size for CD4PE logo

<img width="732" alt="image" src="https://github.com/puppetlabs/design-system/assets/19972737/da2e043e-e5ba-4a9a-90dc-ae2c6bfb13e3">




