### PR TITLE
(CDPE-6706) Fix logo text SVG being cut off on sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## react-components 5.34.9 (2024-04-15)
+
+- [Logo] Increase continuous delivery logo viewBox size to fix issue with logo text being cut off when the `expanded` prop is set to true on the logo component (by [@petergmurphy](https://github.com/petergmurphy))
+
 ## react-components 5.34.8 (2024-04-10)
 
 - [Logo] Revert continuous delivery logo viewBox size due to alignment issues (by [@petergmurphy](https://github.com/petergmurphy))

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.34.8",
+  "version": "5.34.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.34.8",
+  "version": "5.34.9",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/react/library/logo/logos.js
+++ b/packages/react-components/source/react/library/logo/logos.js
@@ -396,7 +396,7 @@ const securityComplianceManagement = () => ({
 });
 
 const continuousDelivery = () => ({
-  viewBox: '0 0 101 33',
+  viewBox: '0 0 107 33',
   svg: (
     <>
       <path


### PR DESCRIPTION
### Description of proposed changes

Increase continuous delivery logo viewBox size to fix issue with logo text being cut off when the `expanded` prop is set to true on the logo component. The problem occurs in the Sidebar component when it adds the `expanded` prop to the Logo, this is the only instance of the `expanded` prop should be used on the Logo.

### Screenshot of proposed changes

Old:

![image](https://github.com/puppetlabs/design-system/assets/57573942/431ad06c-af28-4c69-82b9-8d67bed17232)


New:

![image](https://github.com/puppetlabs/design-system/assets/57573942/6c69c80f-82d2-4742-8d95-6c3db5cfd6c6)

