### PR TITLE
(MAINT) Adjust Security Compliance Management logo viewBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## react-components 5.34.9 (2024-04-29)
+
+- [Logo] Adjust Security Compliance Management logo viewBox to match Continuous Delivery (by [@Lukeaber](https://github.com/Lukeaber))
+
 ## react-components 5.34.8 (2024-04-10)
 
 - [Logo] Revert continuous delivery logo viewBox size due to alignment issues (by [@petergmurphy](https://github.com/petergmurphy))

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.34.8",
+  "version": "5.34.9",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "main": "build/library.js",

--- a/packages/react-components/source/react/library/logo/logos.js
+++ b/packages/react-components/source/react/library/logo/logos.js
@@ -378,7 +378,7 @@ const connectFull = () => ({
 });
 
 const securityComplianceManagement = () => ({
-  viewBox: '0 0 170 40',
+  viewBox: '0 0 170 33',
   svg: (
     <>
       <path


### PR DESCRIPTION
### Description of proposed changes
When comparing the Security Compliance Management logo with the Continuous Delivery logo in the application sidebar. It was very clear that they did not match up correctly. The SCM logo was to small and needed to have the viewBox size adjusted to match CD.

### Screenshot of current
<img width="244" alt="Screenshot 2024-04-29 at 15 12 11" src="https://github.com/puppetlabs/design-system/assets/30826846/590009a4-8d22-4165-b7af-b13bad66485a">
<img width="423" alt="Screenshot 2024-04-29 at 15 12 31" src="https://github.com/puppetlabs/design-system/assets/30826846/eeb13bc5-7203-4b89-be5b-17a0be999fbf">


### Screenshot of proposed changes
<img width="270" alt="Screenshot 2024-04-29 at 15 12 49" src="https://github.com/puppetlabs/design-system/assets/30826846/9911717a-e696-4c5c-bd07-a3adc7987767">
<img width="499" alt="Screenshot 2024-04-29 at 15 13 05" src="https://github.com/puppetlabs/design-system/assets/30826846/352c7073-0163-484a-b771-8053b2658c16">

