### PR TITLE
Update SASS variables to not use @import statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## sass-variables 1.4.5 (2024-06-24)
+
+- Stop using deprecated @import statements in sass. (by [@Lukeaber](https://github.com/Lukeaber) [#695](https://github.com/puppetlabs/design-system/pull/695))
+
 ## uikit1.0.18 (2024-06-24)
 
 - Upgrade dependencies for improved performance and compatibility. (by [@sean-mckenna](https://github.com/sean-mckenna) and [@comfucios](https://github.com/comfucios) in [#676](https://github.com/puppetlabs/design-system/pull/676))

--- a/packages/design-system-website/package-lock.json
+++ b/packages/design-system-website/package-lock.json
@@ -28,6 +28,7 @@
         "@babel/preset-env": "^7.11.0",
         "@babel/preset-react": "^7.10.4",
         "@babel/register": "^7.10.5",
+        "@puppet/sass-variables": "^1.4.3",
         "@webpack-cli/configtest": "^2.1.1",
         "@webpack-cli/info": "^2.0.2",
         "@webpack-cli/serve": "^2.0.5",

--- a/packages/design-system-website/styleguide.scss
+++ b/packages/design-system-website/styleguide.scss
@@ -1,4 +1,4 @@
-@import '~@puppet/sass-variables/index';
+@use '~@puppet/sass-variables' as *;
 
 /********** Homepage **********/
 

--- a/packages/design-system-website/styleguideComponents/StyleGuideRenderer.scss
+++ b/packages/design-system-website/styleguideComponents/StyleGuideRenderer.scss
@@ -1,4 +1,4 @@
-@import '~@puppet/sass-variables/index';
+@use '~@puppet/sass-variables' as *;
 
 .app {
   display: flex;

--- a/packages/design-system-website/styleguideComponents/TableOfContentsRenderer.scss
+++ b/packages/design-system-website/styleguideComponents/TableOfContentsRenderer.scss
@@ -1,4 +1,4 @@
-@import '~@puppet/sass-variables/index';
+@use '~@puppet/sass-variables' as *;
 
 .pds-filter {
   margin-bottom: 4 * $puppet-common-spacing-base;

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@puppet/react-components",
-  "version": "5.34.10",
+  "version": "5.34.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppet/react-components",
-      "version": "5.34.10",
+      "version": "5.34.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
+        "@puppet/sass-variables": "^1.4.4",
         "classnames": "^2.5.1",
         "core-js": "^3.38.1",
         "hoist-non-react-statics": "^3.3.2",
@@ -2699,6 +2700,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@puppet/sass-variables": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@puppet/sass-variables/-/sass-variables-1.4.5.tgz",
+      "integrity": "sha512-88hSScwYrZ6HPqmX5njYOsjopsWNoIwpvfeT2tLuJfQxA3+ok9SR7JqJL9m1D55j7wJIzVO8/qFXPS5cThX8mg=="
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",

--- a/packages/react-layouts/package-lock.json
+++ b/packages/react-layouts/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@puppet/react-layouts",
-  "version": "2.0.0-alpha.11",
+  "version": "2.0.0-alpha.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppet/react-layouts",
-      "version": "2.0.0-alpha.11",
+      "version": "2.0.0-alpha.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppet/react-components": "^5.34.10",
         "@puppet/sass-variables": "^1.4.4",
         "classnames": "^2.5.1",
         "prop-types": "^15.8.1"
@@ -1893,6 +1892,7 @@
       "version": "7.25.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
       "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -3057,43 +3057,6 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@puppet/react-components": {
-      "version": "5.34.10",
-      "resolved": "https://registry.npmjs.org/@puppet/react-components/-/react-components-5.34.10.tgz",
-      "integrity": "sha512-d/1iSzDIEsNBIANKq5lA8r25Z6cDzx7VPeTV8Zya3uthnkKqcrC1CuSdk8hzaah/EH0Q+aCgeJ39Yyg4eQQ+oA==",
-      "dependencies": {
-        "@popperjs/core": "^2.9.2",
-        "@puppet/sass-variables": "^1.4.3",
-        "classnames": "^2.2.6",
-        "core-js": "^3.6.5",
-        "hoist-non-react-statics": "^3.3.1",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2",
-        "react-modal": "^3.11.2",
-        "react-popper": "^2.2.5",
-        "react-transition-group": "^4.4.1",
-        "regenerator-runtime": "^0.13.7",
-        "scroll-into-view-if-needed": "^2.2.25"
-      },
-      "peerDependencies": {
-        "react": "^16.13.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.13.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@puppet/react-components/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/@puppet/sass-variables": {
       "version": "1.4.4",
@@ -5269,11 +5232,6 @@
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
       "dev": true
     },
-    "node_modules/compute-scroll-into-view": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5429,16 +5387,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.38.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
-      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat": {
@@ -5791,11 +5739,6 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6131,15 +6074,6 @@
       "dev": true,
       "dependencies": {
         "utila": "~0.4"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -7568,11 +7502,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
-    },
     "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -8348,6 +8277,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -11379,7 +11309,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -12775,6 +12706,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -12788,6 +12720,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -12797,11 +12730,6 @@
       "peerDependencies": {
         "react": "^16.14.0"
       }
-    },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-i18next": {
       "version": "15.0.2",
@@ -12829,43 +12757,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "node_modules/react-modal": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
-      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
-      "dependencies": {
-        "exenv": "^1.2.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.0",
-        "warning": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
-        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
-      }
-    },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
     },
     "node_modules/react-router": {
       "version": "5.3.4",
@@ -12933,21 +12824,6 @@
       },
       "peerDependencies": {
         "react": "^16.13.1"
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/readable-stream": {
@@ -13035,7 +12911,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -13490,6 +13367,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13547,14 +13425,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
-    },
-    "node_modules/scroll-into-view-if-needed": {
-      "version": "2.2.31",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
-      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
-      "dependencies": {
-        "compute-scroll-into-view": "^1.0.20"
-      }
     },
     "node_modules/semver": {
       "version": "5.7.2",
@@ -14783,14 +14653,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {

--- a/packages/sass-variables/README.md
+++ b/packages/sass-variables/README.md
@@ -1,4 +1,4 @@
-# Puppet  Sass Variables
+# Puppet Sass Variables
 
 Puppet Sass Variables is a set of public Sass variables corresponding to Puppet Design System color palettes, typography, borders, and spacing.
 
@@ -13,7 +13,7 @@ npm install @puppet/sass-variables
 Reference the public variables from your Sass files:
 
 ```scss
-@import '~@puppet/sass-variables/index';
+@use '~@puppet/sass-variables' as *;
 
 .my-text {
   color: $puppet-amber;
@@ -21,7 +21,7 @@ Reference the public variables from your Sass files:
 ```
 
 ```scss
-@import '~@puppet/sass-variables/index';
+@use '~@puppet/sass-variables' as *;
 
 .my-class {
   @include puppet-type-body(subtle);
@@ -31,4 +31,4 @@ Reference the public variables from your Sass files:
 }
 ```
 
-See the Sass files for a complete list of common variables and mixins (e.g. [_common.scss](_common.scss), [_typography.scss](_typography.scss), and color [_palettes.scss](_palettes.scss) )
+See the Sass files for a complete list of common variables and mixins (e.g. [\_common.scss](_common.scss), [\_typography.scss](_typography.scss), and color [\_palettes.scss](_palettes.scss) )

--- a/packages/sass-variables/_common.scss
+++ b/packages/sass-variables/_common.scss
@@ -1,3 +1,5 @@
+@use "palettes";
+
 // This file contains variables considered to be part of the outward-facing API
 // of this library, to be used by consuming apps for one-off components that
 // still need to be consistent with our overall patterns. This variable set should be
@@ -12,24 +14,24 @@ $puppet-common-border-radius: 4px !default;
 $puppet-common-spacing-base: 4px;
 
 // Often used border dividing content
-$puppet-common-border: 1px solid $puppet-n400 !default;
-$puppet-common-border-subtle: 1px solid $puppet-n300 !default;
+$puppet-common-border: 1px solid palettes.$puppet-n400 !default;
+$puppet-common-border-subtle: 1px solid palettes.$puppet-n300 !default;
 
 // Often used content backgrounds
-$puppet-common-bg: $puppet-white !default;
-$puppet-common-bg-subtle: $puppet-n300 !default;
+$puppet-common-bg: palettes.$puppet-white !default;
+$puppet-common-bg-subtle: palettes.$puppet-n300 !default;
 
 // Common focused element outline, implemented as a box shadow
-$puppet-common-focus-outline: 0 0 0 2px $puppet-b300 !default;
+$puppet-common-focus-outline: 0 0 0 2px palettes.$puppet-b300 !default;
 $puppet-common-focus-outline-inset: inset $puppet-common-focus-outline !default;
 
 $puppet-common-disabled-opacity: 0.4;
 
-$puppet-common-elevation-50: 1px 1px 2px rgba($puppet-black, 0.08);
-$puppet-common-elevation-100: 1px 1px 2px rgba($puppet-black, 0.16);
-$puppet-common-elevation-150: 2px 2px 4px rgba($puppet-black, 0.16);
-$puppet-common-elevation-200: 2px 2px 8px rgba($puppet-black, 0.16);
-$puppet-common-elevation-400: 8px 8px 16px rgba($puppet-black, 0.16);
-$puppet-common-elevation-800: 8px 8px 32px rgba($puppet-black, 0.16);
+$puppet-common-elevation-50: 1px 1px 2px rgba(palettes.$puppet-black, 0.08);
+$puppet-common-elevation-100: 1px 1px 2px rgba(palettes.$puppet-black, 0.16);
+$puppet-common-elevation-150: 2px 2px 4px rgba(palettes.$puppet-black, 0.16);
+$puppet-common-elevation-200: 2px 2px 8px rgba(palettes.$puppet-black, 0.16);
+$puppet-common-elevation-400: 8px 8px 16px rgba(palettes.$puppet-black, 0.16);
+$puppet-common-elevation-800: 8px 8px 32px rgba(palettes.$puppet-black, 0.16);
 
 $puppet-common-transition-duration: 0.6s;

--- a/packages/sass-variables/_fonts.scss
+++ b/packages/sass-variables/_fonts.scss
@@ -1,8 +1,10 @@
+@use "common";
+
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('#{$puppet-common-font-path}/OpenSans-Regular.woff2') format('woff2');
+  src: url('#{common.$puppet-common-font-path}/OpenSans-Regular.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -11,7 +13,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 400;
-  src: url('#{$puppet-common-font-path}/OpenSans-RegularItalic.woff2')
+  src: url('#{common.$puppet-common-font-path}/OpenSans-RegularItalic.woff2')
     format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -21,7 +23,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 600;
-  src: url('#{$puppet-common-font-path}/OpenSans-Semibold.woff2')
+  src: url('#{common.$puppet-common-font-path}/OpenSans-Semibold.woff2')
     format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -31,7 +33,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 600;
-  src: url('#{$puppet-common-font-path}/OpenSans-SemiboldItalic.woff2')
+  src: url('#{common.$puppet-common-font-path}/OpenSans-SemiboldItalic.woff2')
     format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -41,7 +43,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 700;
-  src: url('#{$puppet-common-font-path}/OpenSans-Bold.woff2') format('woff2');
+  src: url('#{common.$puppet-common-font-path}/OpenSans-Bold.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -50,7 +52,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 700;
-  src: url('#{$puppet-common-font-path}/OpenSans-BoldItalic.woff2')
+  src: url('#{common.$puppet-common-font-path}/OpenSans-BoldItalic.woff2')
     format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -61,17 +63,17 @@
   font-style: normal;
   font-weight: 600;
   src:
-    url('#{$puppet-common-font-path}/CalibreWeb-Semibold.woff2') format('woff2'),
-    url('#{$puppet-common-font-path}/CalibreWeb-Semibold.woff') format('woff');
+    url('#{common.$puppet-common-font-path}/CalibreWeb-Semibold.woff2') format('woff2'),
+    url('#{common.$puppet-common-font-path}/CalibreWeb-Semibold.woff') format('woff');
 }
 @font-face {
   font-family: Calibre;
   font-style: italic;
   font-weight: 600;
   src:
-    url('#{$puppet-common-font-path}/CalibreWeb-SemiboldItalic.woff2')
+    url('#{common.$puppet-common-font-path}/CalibreWeb-SemiboldItalic.woff2')
     format('woff2'),
-    url('#{$puppet-common-font-path}/CalibreWeb-SemiboldItalic.woff')
+    url('#{common.$puppet-common-font-path}/CalibreWeb-SemiboldItalic.woff')
     format('woff');
 }
 
@@ -80,8 +82,8 @@
   font-style: normal;
   font-weight: 400;
   src:
-    url('#{$puppet-common-font-path}/Inconsolata-Regular.woff2') format('woff2'),
-    url('#{$puppet-common-font-path}/Inconsolata-Regular.woff') format('woff');
+    url('#{common.$puppet-common-font-path}/Inconsolata-Regular.woff2') format('woff2'),
+    url('#{common.$puppet-common-font-path}/Inconsolata-Regular.woff') format('woff');
 }
 
 @font-face {
@@ -89,6 +91,6 @@
   font-style: normal;
   font-weight: 700;
   src:
-    url('#{$puppet-common-font-path}/Inconsolata-Bold.woff2') format('woff2'),
-    url('#{$puppet-common-font-path}/Inconsolata-Bold.woff') format('woff');
+    url('#{common.$puppet-common-font-path}/Inconsolata-Bold.woff2') format('woff2'),
+    url('#{common.$puppet-common-font-path}/Inconsolata-Bold.woff') format('woff');
 }

--- a/packages/sass-variables/_index.scss
+++ b/packages/sass-variables/_index.scss
@@ -1,6 +1,6 @@
-@import './palettes';
-@import './common';
-@import './fonts';
-@import './typography';
-@import './responsive';
-@import './animations';
+@forward './palettes';
+@forward './common';
+@forward './fonts';
+@forward './typography';
+@forward './responsive';
+@forward './animations';

--- a/packages/sass-variables/_responsive.scss
+++ b/packages/sass-variables/_responsive.scss
@@ -12,7 +12,7 @@ $breakpoints: (
       @content;
     }
   } @else {
-    @warn "Unrecognized breakpoint '#{$breakpoint}'. Available breakpoints are: #{map-keys($breakpoints)}.";
+    @warn "Unrecognized breakpoint '#{$breakpoint}'. Available breakpoints are: #{map.keys($breakpoints)}.";
   }
 }
 
@@ -22,6 +22,6 @@ $breakpoints: (
       @content;
     }
   } @else {
-    @warn "Unrecognized breakpoint '#{$breakpoint}'. Available breakpoints are: #{map-keys($breakpoints)}.";
+    @warn "Unrecognized breakpoint '#{$breakpoint}'. Available breakpoints are: #{map.keys($breakpoints)}.";
   }
 }

--- a/packages/sass-variables/_typography.scss
+++ b/packages/sass-variables/_typography.scss
@@ -1,3 +1,6 @@
+@use "common";
+@use "palettes";
+
 @use 'sass:map';
 
 // Common font families
@@ -13,16 +16,16 @@ $puppet-type-weight-heavy: 600 !default;
 $puppet-type-spacing-medium: 0.4px !default;
 
 // Common colors
-$puppet-type-color-base: $puppet-n900 !default;
-$puppet-type-color-medium: $puppet-n700 !default;
-$puppet-type-color-subtle: $puppet-n600 !default;
-$puppet-type-color-success: $puppet-g700 !default;
-$puppet-type-color-warning: $puppet-y600 !default;
-$puppet-type-color-danger: $puppet-r600 !default;
-$puppet-type-color-link: $puppet-b500 !default;
-$puppet-type-color-link-hover: $puppet-b400 !default;
-$puppet-type-color-link-active: $puppet-b600 !default;
-$puppet-type-color-white: $puppet-white !default;
+$puppet-type-color-base: palettes.$puppet-n900 !default;
+$puppet-type-color-medium: palettes.$puppet-n700 !default;
+$puppet-type-color-subtle: palettes.$puppet-n600 !default;
+$puppet-type-color-success: palettes.$puppet-g700 !default;
+$puppet-type-color-warning: palettes.$puppet-y600 !default;
+$puppet-type-color-danger: palettes.$puppet-r600 !default;
+$puppet-type-color-link: palettes.$puppet-b500 !default;
+$puppet-type-color-link-hover: palettes.$puppet-b400 !default;
+$puppet-type-color-link-active: palettes.$puppet-b600 !default;
+$puppet-type-color-white: palettes.$puppet-white !default;
 
 // Map is useful internally for mixins below
 $puppet-type-colors: (
@@ -240,7 +243,7 @@ $puppet-type-code-small-font-weight: $puppet-type-weight-normal !default;
   }
 
   &:focus {
-    box-shadow: inset 0 -4px 0 -1px $puppet-b100;
+    box-shadow: inset 0 -4px 0 -1px palettes.$puppet-b100;
     color: $puppet-type-color-link;
     text-decoration: none;
   }
@@ -253,7 +256,7 @@ $puppet-type-code-small-font-weight: $puppet-type-weight-normal !default;
 
   &:disabled,
   &[aria-disabled='true'] {
-    opacity: $puppet-common-disabled-opacity;
+    opacity: common.$puppet-common-disabled-opacity;
     pointer-events: none;
   }
 }

--- a/packages/sass-variables/package-lock.json
+++ b/packages/sass-variables/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@puppet/sass-variables",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@puppet/sass-variables",
-      "version": "1.4.4",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "prettier": "^3.3.3",

--- a/packages/sass-variables/package.json
+++ b/packages/sass-variables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puppet/sass-variables",
-  "version": "1.4.5",
+  "version": "2.0.0",
   "author": "Puppet, Inc.",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
### Description of proposed changes

In comply we are getting hundreds of deprecated sass warnings around the use of the @import statements. The issue is because theses are coming from a dependancy they are very hard to suppress. 



