### PR TITLE
Update Node.js version in CI workflows to 20.9.0 for consistency across deployment and publishing processes.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.9.0
       - run: npm install
       - run: npm run build --if-present
       - run: npm test
@@ -29,7 +29,7 @@ jobs:
       - name: Set Node version
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.9.0
       - name: Install
         run: |
           cd packages/design-system-website

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.9.0
       - run: npm install
       - run: npm run build --if-present
       - run: npm test
@@ -29,7 +29,7 @@ jobs:
       - name: Set Node version
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.9.0
           registry-url: https://registry.npmjs.org
       - name: Install all package dependencies
         run: npm install


### PR DESCRIPTION
Pin the node version so that the unit tests work across the github workflows.